### PR TITLE
Add sync history page and rename dashboard (#3, #5)

### DIFF
--- a/app/dashboard/creators/actions.ts
+++ b/app/dashboard/creators/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 
 export async function getBrands() {
@@ -26,12 +27,15 @@ export type CreatorMetric = {
 
 export async function syncAdMetrics() {
   const supabase = await createClient();
-  const { data, error } = await supabase.functions.invoke("sync-ad-metrics");
+  const { data, error } = await supabase.functions.invoke("sync-ad-metrics", {
+    body: { trigger: "manual" },
+  });
 
   if (error) {
     return { success: false as const, error: error.message };
   }
 
+  revalidatePath("/dashboard/sync");
   return { success: true as const, results: data };
 }
 

--- a/app/dashboard/creators/page.tsx
+++ b/app/dashboard/creators/page.tsx
@@ -20,7 +20,7 @@ export default async function CreatorsPage({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Creators</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Tabela Mensal</h1>
         <SyncButton />
       </div>
       <CreatorsTable

--- a/app/dashboard/sync/actions.ts
+++ b/app/dashboard/sync/actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type SyncLog = {
+  id: string;
+  started_at: string;
+  finished_at: string | null;
+  status: "running" | "success" | "error";
+  trigger: "manual" | "scheduled";
+  creatives_upserted: number;
+  metrics_upserted: number;
+  unmatched_ads: number;
+  error_message: string | null;
+};
+
+export async function getSyncLogs(): Promise<SyncLog[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("sync_logs")
+    .select("*")
+    .order("started_at", { ascending: false })
+    .limit(50);
+
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}

--- a/app/dashboard/sync/page.tsx
+++ b/app/dashboard/sync/page.tsx
@@ -1,0 +1,17 @@
+import { SyncButton } from "@/components/sync-button";
+import { SyncHistoryTable } from "@/components/sync-history-table";
+import { getSyncLogs } from "./actions";
+
+export default async function SyncPage() {
+  const logs = await getSyncLogs();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Sincronização</h1>
+        <SyncButton />
+      </div>
+      <SyncHistoryTable logs={logs} />
+    </div>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Users, UserPlus, Building2 } from "lucide-react";
+import { TableProperties, UserPlus, Building2, History } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -10,27 +10,43 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
-const navItems = [
+const navSections = [
   {
-    title: "Creators",
-    href: "/dashboard/creators",
-    icon: Users,
+    label: "Dashboards",
+    items: [
+      {
+        title: "Tabela Mensal",
+        href: "/dashboard/creators",
+        icon: TableProperties,
+      },
+    ],
   },
   {
-    title: "Gerenciar Creators",
-    href: "/dashboard/creators/list",
-    icon: UserPlus,
-  },
-  {
-    title: "Marcas",
-    href: "/dashboard/brands",
-    icon: Building2,
+    label: "Gestão",
+    items: [
+      {
+        title: "Gerenciar Creators",
+        href: "/dashboard/creators/list",
+        icon: UserPlus,
+      },
+      {
+        title: "Marcas",
+        href: "/dashboard/brands",
+        icon: Building2,
+      },
+      {
+        title: "Sincronização",
+        href: "/dashboard/sync",
+        icon: History,
+      },
+    ],
   },
 ];
 
@@ -56,28 +72,31 @@ export function AppSidebar({ user }: { user: { email: string } | null }) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        <SidebarGroup>
-          <SidebarMenu>
-            {navItems.map((item) => (
-              <SidebarMenuItem key={item.href}>
-                <SidebarMenuButton
-                  asChild
-                  isActive={
-                    item.href === "/dashboard/creators"
-                      ? pathname === "/dashboard/creators"
-                      : pathname.startsWith(item.href)
-                  }
-                  tooltip={item.title}
-                >
-                  <Link href={item.href}>
-                    <item.icon />
-                    <span>{item.title}</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
+        {navSections.map((section) => (
+          <SidebarGroup key={section.label}>
+            <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
+            <SidebarMenu>
+              {section.items.map((item) => (
+                <SidebarMenuItem key={item.href}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={
+                      item.href === "/dashboard/creators"
+                        ? pathname === "/dashboard/creators"
+                        : pathname.startsWith(item.href)
+                    }
+                    tooltip={item.title}
+                  >
+                    <Link href={item.href}>
+                      <item.icon />
+                      <span>{item.title}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroup>
+        ))}
       </SidebarContent>
       <SidebarFooter>
         {user ? (

--- a/components/sync-history-table.tsx
+++ b/components/sync-history-table.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AlertCircle } from "lucide-react";
+import type { SyncLog } from "@/app/dashboard/sync/actions";
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (!finishedAt) return "—";
+  const ms = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
+function StatusBadge({ status }: { status: SyncLog["status"] }) {
+  const variants: Record<SyncLog["status"], { label: string; className: string }> = {
+    running: {
+      label: "Em execução",
+      className: "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
+    },
+    success: {
+      label: "Sucesso",
+      className: "bg-green-100 text-green-800 hover:bg-green-100",
+    },
+    error: {
+      label: "Erro",
+      className: "bg-red-100 text-red-800 hover:bg-red-100",
+    },
+  };
+
+  const { label, className } = variants[status];
+  return (
+    <Badge variant="secondary" className={className}>
+      {label}
+    </Badge>
+  );
+}
+
+function TriggerBadge({ trigger }: { trigger: SyncLog["trigger"] }) {
+  return (
+    <Badge variant="outline">
+      {trigger === "manual" ? "Manual" : "Agendado"}
+    </Badge>
+  );
+}
+
+export function SyncHistoryTable({ logs }: { logs: SyncLog[] }) {
+  if (logs.length === 0) {
+    return (
+      <div className="flex items-center justify-center rounded-md border border-dashed p-8">
+        <p className="text-sm text-muted-foreground">
+          Nenhuma sincronização registrada.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Data/Hora</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Duração</TableHead>
+              <TableHead className="text-right">Criativos</TableHead>
+              <TableHead className="text-right">Métricas</TableHead>
+              <TableHead className="text-right">Não casados</TableHead>
+              <TableHead>Gatilho</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log) => (
+              <TableRow key={log.id}>
+                <TableCell className="whitespace-nowrap">
+                  {formatDateTime(log.started_at)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1.5">
+                    <StatusBadge status={log.status} />
+                    {log.status === "error" && log.error_message && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <AlertCircle className="h-4 w-4 text-red-500 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="right"
+                          className="max-w-xs text-xs"
+                        >
+                          {log.error_message}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {formatDuration(log.started_at, log.finished_at)}
+                </TableCell>
+                <TableCell className="text-right">
+                  {log.creatives_upserted}
+                </TableCell>
+                <TableCell className="text-right">
+                  {log.metrics_upserted}
+                </TableCell>
+                <TableCell className="text-right">
+                  {log.unmatched_ads}
+                </TableCell>
+                <TableCell>
+                  <TriggerBadge trigger={log.trigger} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/docs/issues_proximos_passos.md
+++ b/docs/issues_proximos_passos.md
@@ -1,8 +1,8 @@
 # Próximos passos — Issues planejadas
 
-**Data:** 2026-03-15
+**Última atualização:** 2026-03-15
 **Repo:** `joaovitormesquita-goca/gocreators-dash`
-**Total de issues:** 8
+**Total de issues:** 8 | **Concluídas:** 1/8 (12,5%)
 
 > **Para agentes/Claude Code:** As issues completas estão no GitHub. Para puxar a descrição de qualquer issue, use:
 > ```bash
@@ -12,23 +12,23 @@
 
 ## Índice de issues
 
-| # | Issue | Link |
-|---|-------|------|
-| 1 | Tela de gerenciamento de marcas com ad accounts | [#1](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/1) |
-| 2 | Agendamento diário do ETL (antes das 6h) | [#2](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/2) |
-| 3 | Tabela e tela de histórico de sincronização | [#3](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/3) |
-| 4 | Nova tabela e ETL de gasto total diário por ad account | [#4](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/4) |
-| 5 | Renomear dashboard de Creators para Tabela Mensal | [#5](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/5) |
-| 6 | Visão Mensal com gráficos de gasto e share % | [#6](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/6) |
-| 7 | Visão Diária com gráfico de gasto e share % | [#7](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/7) |
-| 8 | Tela de dados individuais por creator (draft) | [#8](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/8) |
+| # | Issue | Status | Link |
+|---|-------|--------|------|
+| 1 | Tela de gerenciamento de marcas com ad accounts | ✅ Concluída | [#1](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/1) |
+| 2 | Agendamento diário do ETL (antes das 6h) | ⬚ Pendente | [#2](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/2) |
+| 3 | Tabela e tela de histórico de sincronização | ⬚ Pendente | [#3](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/3) |
+| 4 | Nova tabela e ETL de gasto total diário por ad account | ⬚ Pendente | [#4](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/4) |
+| 5 | Renomear dashboard de Creators para Tabela Mensal | ⬚ Pendente | [#5](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/5) |
+| 6 | Visão Mensal com gráficos de gasto e share % | ⬚ Pendente | [#6](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/6) |
+| 7 | Visão Diária com gráfico de gasto e share % | ⬚ Pendente | [#7](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/7) |
+| 8 | Tela de dados individuais por creator (draft) | 🟡 Draft | [#8](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/8) |
 
 ---
 
 ## Mapa de dependências
 
 ```
-#1 Marcas/Ad Accounts ──────────────────────── (independente)
+#1 Marcas/Ad Accounts ──────────────────────── ✅ CONCLUÍDA
 
 #2 Agendamento ETL ─────────┐
                              ├── complementares (#2 registra na tabela que #3 cria)
@@ -47,44 +47,50 @@
 
 | Trilha | Issues | Ordem |
 |--------|--------|-------|
-| **A — Gestão** | #1 | Independente |
+| **A — Gestão** | ~~#1~~ ✅ | Concluída |
 | **B — ETL/Sync** | #3 → #2 → #4 | #3 cria `sync_logs` e atualiza Edge Function, #2 agenda, #4 expande ETL |
 | **C — Dashboards** | #5 → #6 → #7 | #5 reorganiza navegação, #6 e #7 dependem de #4 |
 
-Trilhas A e B podem começar em paralelo. Trilha C começa com #5 (rápida) e depende de #4 (trilha B) para #6 e #7.
+Trilha A está concluída. Trilha B pode começar imediatamente. Trilha C começa com #5 (rápida) e depende de #4 (trilha B) para #6 e #7.
+
+## Próximas prioridades
+
+Com a issue #1 concluída, as próximas issues recomendadas são:
+
+1. **#3 — Histórico de Sync** (desbloqueia #2) — criar tabela `sync_logs` e atualizar Edge Function
+2. **#5 — Renomear para Tabela Mensal** (rápida, independente) — reorganizar navegação
+3. **#2 — Agendamento ETL** (depende de #3) — configurar cron
+4. **#4 — Gasto total por ad account** (desbloqueia #6 e #7) — nova tabela + ETL
+5. **#6 e #7 — Visões com gráficos** (dependem de #4 e #5) — dashboards Recharts
 
 ---
 
 ## Issues
 
-### [#1](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/1) — Tela de gerenciamento de marcas com ad accounts
+### [#1](https://github.com/joaovitormesquita-goca/gocreators-dash/issues/1) — ✅ Tela de gerenciamento de marcas com ad accounts
 
 **Labels:** `frontend`, `backend`, `enhancement`
 **Dependências:** nenhuma
+**Status:** Concluída (PR [#9](https://github.com/joaovitormesquita-goca/gocreators-dash/pull/9))
 
 **Contexto:** Marcas e ad accounts existem no banco mas não têm interface de gestão.
 
-**Requisitos:**
-- Página `/dashboard/brands`
-- Listagem de marcas com expansão para ver ad accounts vinculadas (`meta_account_id`)
-- CRUD de marcas: criar, editar, remover (dialog)
-- CRUD de ad accounts dentro de cada marca: criar, editar, desvincular (inline ou dialog)
-- Validação com Zod
-- Server actions seguindo padrão de `/dashboard/creators/list`
-
-**Referência:**
-- UI: `CreateCreatorDialog`, `EditCreatorDialog`
-- Server actions: `/app/dashboard/creators/list/actions.ts`
-- Schemas: `supabase/schemas/brands.sql`, `supabase/schemas/ad_accounts.sql`
+**O que foi implementado:**
+- Página `/dashboard/brands` com tabela expansível (marcas → ad accounts)
+- CRUD completo de marcas: `CreateBrandDialog`, `EditBrandDialog`, `DeleteConfirmDialog`
+- CRUD completo de ad accounts: `CreateAdAccountDialog`, `EditAdAccountDialog`
+- Server actions em `app/dashboard/brands/actions.ts`
+- Validação com Zod em `lib/schemas/brand`
+- Link "Marcas" adicionado ao sidebar
 
 **Critérios de aceite:**
-- [ ] Listar marcas com suas ad accounts
-- [ ] Criar nova marca
-- [ ] Editar marca existente
-- [ ] Remover marca (com confirmação)
-- [ ] Adicionar ad account a uma marca
-- [ ] Editar ad account
-- [ ] Remover ad account de uma marca
+- [x] Listar marcas com suas ad accounts
+- [x] Criar nova marca
+- [x] Editar marca existente
+- [x] Remover marca (com confirmação)
+- [x] Adicionar ad account a uma marca
+- [x] Editar ad account
+- [x] Remover ad account de uma marca
 
 ---
 

--- a/supabase/functions/sync-ad-metrics/index.ts
+++ b/supabase/functions/sync-ad-metrics/index.ts
@@ -5,7 +5,13 @@ import { buildMetabaseQuery } from "./queries.ts";
 import type { AdAccount, CreatorBrand, MetabaseRow, SyncResult } from "./types.ts";
 
 Deno.serve(async (_req: Request) => {
+  let syncLogId: string | null = null;
+  let supabase: ReturnType<typeof createClient> | null = null;
+
   try {
+    // Parse request body for trigger type
+    const body = await _req.json().catch(() => ({}));
+    const trigger = body.trigger === "scheduled" ? "scheduled" : "manual";
     const metabaseUrl = Deno.env.get("METABASE_URL");
     const metabaseUsername = Deno.env.get("METABASE_USERNAME");
     const metabasePassword = Deno.env.get("METABASE_PASSWORD");
@@ -27,7 +33,15 @@ Deno.serve(async (_req: Request) => {
       );
     }
 
-    const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+    supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+    // Create sync log entry
+    const { data: logRow } = await supabase
+      .from("sync_logs")
+      .insert({ status: "running", trigger })
+      .select("id")
+      .single();
+    syncLogId = logRow?.id ?? null;
 
     const metabase = new MetabaseClient(
       metabaseUrl,
@@ -94,10 +108,49 @@ Deno.serve(async (_req: Request) => {
       }
     }
 
+    // Update sync log with final results
+    if (syncLogId && supabase) {
+      const totals = results.reduce(
+        (acc, r) => ({
+          creatives_upserted: acc.creatives_upserted + r.creatives_upserted,
+          metrics_upserted: acc.metrics_upserted + r.metrics_upserted,
+          unmatched_ads: acc.unmatched_ads + r.unmatched_ads,
+        }),
+        { creatives_upserted: 0, metrics_upserted: 0, unmatched_ads: 0 },
+      );
+
+      const errors = results
+        .filter((r) => r.error)
+        .map((r) => `${r.account_id}: ${r.error}`);
+      const hasErrors = errors.length > 0;
+
+      await supabase
+        .from("sync_logs")
+        .update({
+          finished_at: new Date().toISOString(),
+          status: hasErrors ? "error" : "success",
+          ...totals,
+          error_message: hasErrors ? errors.join("; ") : null,
+        })
+        .eq("id", syncLogId);
+    }
+
     return new Response(JSON.stringify({ results }), {
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
+    // Update sync log with error status
+    if (syncLogId && supabase) {
+      await supabase
+        .from("sync_logs")
+        .update({
+          finished_at: new Date().toISOString(),
+          status: "error",
+          error_message: err instanceof Error ? err.message : String(err),
+        })
+        .eq("id", syncLogId);
+    }
+
     return new Response(
       JSON.stringify({
         error: err instanceof Error ? err.message : String(err),

--- a/supabase/migrations/20260316123551_add_sync_logs_table.sql
+++ b/supabase/migrations/20260316123551_add_sync_logs_table.sql
@@ -1,0 +1,69 @@
+
+  create table "public"."sync_logs" (
+    "id" uuid not null default gen_random_uuid(),
+    "started_at" timestamp with time zone not null default now(),
+    "finished_at" timestamp with time zone,
+    "status" text not null default 'running'::text,
+    "trigger" text not null default 'manual'::text,
+    "creatives_upserted" integer not null default 0,
+    "metrics_upserted" integer not null default 0,
+    "unmatched_ads" integer not null default 0,
+    "error_message" text
+      );
+
+
+CREATE UNIQUE INDEX sync_logs_pkey ON public.sync_logs USING btree (id);
+
+alter table "public"."sync_logs" add constraint "sync_logs_pkey" PRIMARY KEY using index "sync_logs_pkey";
+
+alter table "public"."sync_logs" add constraint "sync_logs_status_check" CHECK ((status = ANY (ARRAY['running'::text, 'success'::text, 'error'::text]))) not valid;
+
+alter table "public"."sync_logs" validate constraint "sync_logs_status_check";
+
+alter table "public"."sync_logs" add constraint "sync_logs_trigger_check" CHECK ((trigger = ANY (ARRAY['manual'::text, 'scheduled'::text]))) not valid;
+
+alter table "public"."sync_logs" validate constraint "sync_logs_trigger_check";
+
+grant delete on table "public"."sync_logs" to "anon";
+
+grant insert on table "public"."sync_logs" to "anon";
+
+grant references on table "public"."sync_logs" to "anon";
+
+grant select on table "public"."sync_logs" to "anon";
+
+grant trigger on table "public"."sync_logs" to "anon";
+
+grant truncate on table "public"."sync_logs" to "anon";
+
+grant update on table "public"."sync_logs" to "anon";
+
+grant delete on table "public"."sync_logs" to "authenticated";
+
+grant insert on table "public"."sync_logs" to "authenticated";
+
+grant references on table "public"."sync_logs" to "authenticated";
+
+grant select on table "public"."sync_logs" to "authenticated";
+
+grant trigger on table "public"."sync_logs" to "authenticated";
+
+grant truncate on table "public"."sync_logs" to "authenticated";
+
+grant update on table "public"."sync_logs" to "authenticated";
+
+grant delete on table "public"."sync_logs" to "service_role";
+
+grant insert on table "public"."sync_logs" to "service_role";
+
+grant references on table "public"."sync_logs" to "service_role";
+
+grant select on table "public"."sync_logs" to "service_role";
+
+grant trigger on table "public"."sync_logs" to "service_role";
+
+grant truncate on table "public"."sync_logs" to "service_role";
+
+grant update on table "public"."sync_logs" to "service_role";
+
+

--- a/supabase/schemas/08_sync_logs.sql
+++ b/supabase/schemas/08_sync_logs.sql
@@ -1,0 +1,13 @@
+create table if not exists "public"."sync_logs" (
+  "id" uuid primary key default gen_random_uuid(),
+  "started_at" timestamptz not null default now(),
+  "finished_at" timestamptz,
+  "status" text not null default 'running'
+    check ("status" in ('running', 'success', 'error')),
+  "trigger" text not null default 'manual'
+    check ("trigger" in ('manual', 'scheduled')),
+  "creatives_upserted" integer not null default 0,
+  "metrics_upserted" integer not null default 0,
+  "unmatched_ads" integer not null default 0,
+  "error_message" text
+);


### PR DESCRIPTION
## Summary

- **Issue #3** — Tabela e tela de histórico de sincronização:
  - Schema `sync_logs` + migration para rastrear execuções do ETL
  - Edge Function `sync-ad-metrics` agora registra cada execução (status, trigger, contadores, erros)
  - Nova página `/dashboard/sync` com tabela de histórico (status badge, duração, registros processados)
  - Server action `getSyncLogs()` para consultar histórico

- **Issue #5** — Renomear dashboard de Creators para Tabela Mensal:
  - Título da página renomeado de "Creators" para "Tabela Mensal"
  - Sidebar reorganizado em seções "Dashboards" e "Gestão"
  - Link "Sincronização" adicionado à seção Gestão

- **Docs**: Roadmap atualizado com status de progresso das issues

## Test plan

- [x] Acessar `/dashboard/sync` e verificar que a tabela de histórico renderiza
- [x] Disparar sync manual e confirmar que novo registro aparece na tabela
- [x] Verificar que o sidebar mostra "Tabela Mensal" em vez de "Creators"
- [x] Verificar seções "Dashboards" e "Gestão" no sidebar
- [x] Confirmar que a migration `add_sync_logs_table` aplica sem erros (`supabase migration up`)

Closes #3, closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)