### PR TITLE
Add bulk CSV import for creators

### DIFF
--- a/app/dashboard/creators/list/actions.ts
+++ b/app/dashboard/creators/list/actions.ts
@@ -8,6 +8,11 @@ import {
   type CreateCreatorInput,
   type EditCreatorInput,
 } from "@/lib/schemas/creator";
+import {
+  bulkImportSchema,
+  type BulkImportInput,
+  type BulkImportResult,
+} from "@/lib/schemas/csv-import";
 
 export type CreatorBrand = {
   id: number;
@@ -217,4 +222,105 @@ export async function updateCreator(
 
   revalidatePath("/dashboard/creators/list");
   return { success: true };
+}
+
+export async function bulkImportCreators(
+  input: BulkImportInput,
+): Promise<BulkImportResult> {
+  const parsed = bulkImportSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message };
+  }
+
+  const { brandId, newCreators, existingCreatorLinks } = parsed.data;
+  const supabase = await createClient();
+  const errors: Array<{ name: string; error: string }> = [];
+  let createdCount = 0;
+  let linkedCount = 0;
+  let handleAddedCount = 0;
+
+  // 1. Batch insert new creators
+  if (newCreators.length > 0) {
+    const { data: insertedCreators, error: creatorsError } = await supabase
+      .from("creators")
+      .insert(
+        newCreators.map((c) => ({
+          full_name: c.fullName,
+          email: c.email || null,
+        })),
+      )
+      .select("id, full_name");
+
+    if (creatorsError) {
+      return { success: false, error: creatorsError.message };
+    }
+
+    // Create creator_brands for each new creator
+    const brandRows = (insertedCreators ?? []).map((creator, i) => ({
+      creator_id: creator.id,
+      brand_id: brandId,
+      handles: [newCreators[i].handle],
+      start_date: newCreators[i].startDate,
+    }));
+
+    const { error: brandsError } = await supabase
+      .from("creator_brands")
+      .insert(brandRows);
+
+    if (brandsError) {
+      return { success: false, error: brandsError.message };
+    }
+
+    createdCount = insertedCreators?.length ?? 0;
+  }
+
+  // 2. Link existing creators
+  for (const link of existingCreatorLinks) {
+    if (link.existingAssignmentId) {
+      // Already linked to this brand — append handle
+      const { data: current, error: fetchErr } = await supabase
+        .from("creator_brands")
+        .select("handles")
+        .eq("id", link.existingAssignmentId)
+        .single();
+
+      if (fetchErr) {
+        errors.push({ name: `Creator #${link.creatorId}`, error: fetchErr.message });
+        continue;
+      }
+
+      const currentHandles = (current?.handles as string[]) ?? [];
+      if (!currentHandles.includes(link.handle)) {
+        const { error: updateErr } = await supabase
+          .from("creator_brands")
+          .update({ handles: [...currentHandles, link.handle] })
+          .eq("id", link.existingAssignmentId);
+
+        if (updateErr) {
+          errors.push({ name: `Creator #${link.creatorId}`, error: updateErr.message });
+          continue;
+        }
+        handleAddedCount++;
+      }
+    } else {
+      // Not linked to this brand — create new creator_brands row
+      const { error: insertErr } = await supabase
+        .from("creator_brands")
+        .insert({
+          creator_id: link.creatorId,
+          brand_id: brandId,
+          handles: [link.handle],
+          start_date: link.startDate,
+        });
+
+      if (insertErr) {
+        errors.push({ name: `Creator #${link.creatorId}`, error: insertErr.message });
+        continue;
+      }
+      linkedCount++;
+    }
+  }
+
+  revalidatePath("/dashboard/creators/list");
+  return { success: true, createdCount, linkedCount, handleAddedCount, errors };
 }

--- a/app/dashboard/creators/list/page.tsx
+++ b/app/dashboard/creators/list/page.tsx
@@ -1,5 +1,6 @@
 import { CreatorsListTable } from "@/components/creators-list-table";
 import { CreateCreatorDialog } from "@/components/create-creator-dialog";
+import { ImportCsvDialog } from "@/components/import-csv/import-csv-dialog";
 import {
   getCreatorsWithBrands,
   getBrandsForSelect,
@@ -15,7 +16,10 @@ export default async function CreatorsListPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Creators</h1>
-        <CreateCreatorDialog brands={brands} />
+        <div className="flex items-center gap-2">
+          <ImportCsvDialog brands={brands} existingCreators={creators} />
+          <CreateCreatorDialog brands={brands} />
+        </div>
       </div>
       <CreatorsListTable creators={creators} brands={brands} />
     </div>

--- a/components/import-csv/import-csv-dialog.tsx
+++ b/components/import-csv/import-csv-dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { FileUp } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { bulkImportCreators } from "@/app/dashboard/creators/list/actions";
+import type { CreatorWithBrands } from "@/app/dashboard/creators/list/actions";
+import type { BulkImportResult } from "@/lib/schemas/csv-import";
+
+import { StepUpload } from "./step-upload";
+import { StepMatchCreators } from "./step-match-creators";
+import { StepReview } from "./step-review";
+import { StepResult } from "./step-result";
+import type { ParsedCreator, ResolvedCreator } from "./types";
+
+type Brand = { id: number; name: string };
+
+type Props = {
+  brands: Brand[];
+  existingCreators: CreatorWithBrands[];
+};
+
+const STEP_TITLES: Record<number, string> = {
+  1: "Upload do CSV",
+  2: "Verificação de Duplicatas",
+  3: "Revisão",
+  4: "Resultado",
+};
+
+export function ImportCsvDialog({ brands, existingCreators }: Props) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(1);
+  const [brandId, setBrandId] = useState<number | null>(null);
+  const [parsedCreators, setParsedCreators] = useState<ParsedCreator[]>([]);
+  const [resolvedCreators, setResolvedCreators] = useState<ResolvedCreator[]>([]);
+  const [result, setResult] = useState<BulkImportResult | null>(null);
+  const router = useRouter();
+
+  function reset() {
+    setStep(1);
+    setBrandId(null);
+    setParsedCreators([]);
+    setResolvedCreators([]);
+    setResult(null);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) reset();
+  }
+
+  function handleStep1Next(selectedBrandId: number, creators: ParsedCreator[]) {
+    setBrandId(selectedBrandId);
+    setParsedCreators(creators);
+    setStep(2);
+  }
+
+  function handleStep2Next(resolved: ResolvedCreator[]) {
+    setResolvedCreators(resolved);
+    setStep(3);
+  }
+
+  function handleResult(importResult: BulkImportResult) {
+    setResult(importResult);
+    setStep(4);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    reset();
+    router.refresh();
+  }
+
+  const brandName =
+    brands.find((b) => b.id === brandId)?.name ?? "";
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <FileUp className="mr-2 h-4 w-4" />
+          Importar CSV
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{STEP_TITLES[step]}</DialogTitle>
+          <DialogDescription>
+            Etapa {step} de 4 — Importação de creators via CSV
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 1 && (
+          <StepUpload brands={brands} onNext={handleStep1Next} />
+        )}
+
+        {step === 2 && brandId && (
+          <StepMatchCreators
+            parsedCreators={parsedCreators}
+            existingCreators={existingCreators}
+            brandId={brandId}
+            onNext={handleStep2Next}
+            onBack={() => setStep(1)}
+          />
+        )}
+
+        {step === 3 && brandId && (
+          <StepReview
+            resolved={resolvedCreators}
+            brandId={brandId}
+            brandName={brandName}
+            onImport={bulkImportCreators}
+            onResult={handleResult}
+            onBack={() => setStep(2)}
+          />
+        )}
+
+        {step === 4 && result && (
+          <StepResult result={result} onClose={handleClose} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/import-csv/step-match-creators.tsx
+++ b/components/import-csv/step-match-creators.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, Check, UserPlus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { stringSimilarity } from "@/lib/string-similarity";
+import type { CreatorWithBrands } from "@/app/dashboard/creators/list/actions";
+import type { ParsedCreator, CreatorMatch, ResolvedCreator } from "./types";
+
+const SIMILARITY_THRESHOLD = 0.75;
+
+type Props = {
+  parsedCreators: ParsedCreator[];
+  existingCreators: CreatorWithBrands[];
+  brandId: number;
+  onNext: (resolved: ResolvedCreator[]) => void;
+  onBack: () => void;
+};
+
+export function StepMatchCreators({
+  parsedCreators,
+  existingCreators,
+  brandId,
+  onNext,
+  onBack,
+}: Props) {
+  const initialMatches = useMemo(() => {
+    return parsedCreators.map((parsed): CreatorMatch => {
+      let bestMatch: CreatorWithBrands | null = null;
+      let bestScore = 0;
+
+      for (const existing of existingCreators) {
+        const score = stringSimilarity(parsed.fullName, existing.full_name);
+        if (score > bestScore) {
+          bestScore = score;
+          bestMatch = existing;
+        }
+      }
+
+      const hasPotentialMatch = bestScore >= SIMILARITY_THRESHOLD && bestMatch;
+      const brandLink = bestMatch?.brands.find((b) => b.id === brandId);
+
+      return {
+        parsed,
+        bestMatch: hasPotentialMatch ? bestMatch : null,
+        similarity: hasPotentialMatch ? bestScore : 0,
+        decision: hasPotentialMatch ? "existing" : "new",
+        alreadyLinked: !!brandLink,
+        existingAssignmentId: brandLink?.assignmentId,
+      };
+    });
+  }, [parsedCreators, existingCreators, brandId]);
+
+  const [matches, setMatches] = useState<CreatorMatch[]>(initialMatches);
+
+  function toggleDecision(index: number) {
+    setMatches((prev) =>
+      prev.map((m, i) =>
+        i === index
+          ? { ...m, decision: m.decision === "new" ? "existing" : "new" }
+          : m,
+      ),
+    );
+  }
+
+  function handleNext() {
+    const resolved: ResolvedCreator[] = matches.map((m) => {
+      if (m.decision === "existing" && m.bestMatch) {
+        return {
+          ...m.parsed,
+          type: "existing",
+          creatorId: m.bestMatch.id,
+          creatorName: m.bestMatch.full_name,
+          existingAssignmentId: m.existingAssignmentId,
+        };
+      }
+      return { ...m.parsed, type: "new" };
+    });
+    onNext(resolved);
+  }
+
+  const matchCount = matches.filter(
+    (m) => m.bestMatch && m.similarity >= SIMILARITY_THRESHOLD,
+  ).length;
+  const noMatchCount = matches.length - matchCount;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-3 text-sm">
+        <Badge variant="outline">
+          {noMatchCount} novo(s)
+        </Badge>
+        {matchCount > 0 && (
+          <Badge variant="secondary">
+            {matchCount} possível(is) match(es)
+          </Badge>
+        )}
+      </div>
+
+      <div className="max-h-[400px] overflow-y-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome no CSV</TableHead>
+              <TableHead>Match encontrado</TableHead>
+              <TableHead className="w-24 text-center">Similar.</TableHead>
+              <TableHead className="w-40 text-center">Decisão</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {matches.map((match, i) => (
+              <TableRow key={i}>
+                <TableCell className="font-medium">
+                  {match.parsed.fullName}
+                </TableCell>
+                <TableCell>
+                  {match.bestMatch ? (
+                    <div className="space-y-1">
+                      <span>{match.bestMatch.full_name}</span>
+                      {match.alreadyLinked && match.decision === "existing" && (
+                        <div className="flex items-center gap-1 text-xs text-amber-600">
+                          <AlertTriangle className="h-3 w-3" />
+                          Já vinculado — handle será adicionado
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">
+                  {match.bestMatch ? (
+                    <span className="font-mono text-xs">
+                      {Math.round(match.similarity * 100)}%
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">
+                  {match.bestMatch ? (
+                    <Button
+                      variant={
+                        match.decision === "existing" ? "secondary" : "outline"
+                      }
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={() => toggleDecision(i)}
+                    >
+                      {match.decision === "existing" ? (
+                        <>
+                          <Check className="mr-1 h-3 w-3" />
+                          Mesmo creator
+                        </>
+                      ) : (
+                        <>
+                          <UserPlus className="mr-1 h-3 w-3" />
+                          Novo creator
+                        </>
+                      )}
+                    </Button>
+                  ) : (
+                    <Badge variant="outline" className="text-xs">
+                      <UserPlus className="mr-1 h-3 w-3" />
+                      Novo
+                    </Badge>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          Voltar
+        </Button>
+        <Button onClick={handleNext}>Próximo</Button>
+      </div>
+    </div>
+  );
+}

--- a/components/import-csv/step-result.tsx
+++ b/components/import-csv/step-result.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { BulkImportResult } from "@/lib/schemas/csv-import";
+
+type Props = {
+  result: BulkImportResult;
+  onClose: () => void;
+};
+
+export function StepResult({ result, onClose }: Props) {
+  if (!result.success) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 rounded-md bg-destructive/10 p-4">
+          <XCircle className="h-6 w-6 text-destructive shrink-0" />
+          <div>
+            <p className="font-medium text-destructive">Erro na importação</p>
+            <p className="text-sm text-destructive/80">{result.error}</p>
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={onClose}>Fechar</Button>
+        </div>
+      </div>
+    );
+  }
+
+  const totalSuccess =
+    result.createdCount + result.linkedCount + result.handleAddedCount;
+  const hasErrors = result.errors.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 rounded-md bg-green-50 p-4 dark:bg-green-950/20">
+        <CheckCircle2 className="h-6 w-6 text-green-600 shrink-0" />
+        <div>
+          <p className="font-medium text-green-700 dark:text-green-400">
+            Importação concluída
+          </p>
+          <p className="text-sm text-green-600 dark:text-green-500">
+            {totalSuccess} operação(ões) realizada(s) com sucesso.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-green-600">
+            {result.createdCount}
+          </p>
+          <p className="text-xs text-muted-foreground">Creators criados</p>
+        </div>
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-blue-600">
+            {result.linkedCount}
+          </p>
+          <p className="text-xs text-muted-foreground">Vínculos criados</p>
+        </div>
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-amber-600">
+            {result.handleAddedCount}
+          </p>
+          <p className="text-xs text-muted-foreground">Handles adicionados</p>
+        </div>
+      </div>
+
+      {hasErrors && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm text-amber-600">
+            <AlertTriangle className="h-4 w-4" />
+            <span>{result.errors.length} erro(s) parcial(is):</span>
+          </div>
+          <div className="max-h-32 overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Creator</TableHead>
+                  <TableHead>Erro</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {result.errors.map((err, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{err.name}</TableCell>
+                    <TableCell className="text-sm text-destructive">
+                      {err.error}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button onClick={onClose}>Fechar</Button>
+      </div>
+    </div>
+  );
+}

--- a/components/import-csv/step-review.tsx
+++ b/components/import-csv/step-review.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useTransition } from "react";
+import { format, parseISO } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { UserPlus, Link, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { ResolvedCreator } from "./types";
+import type { BulkImportInput, BulkImportResult } from "@/lib/schemas/csv-import";
+
+type Props = {
+  resolved: ResolvedCreator[];
+  brandId: number;
+  brandName: string;
+  onImport: (input: BulkImportInput) => Promise<BulkImportResult>;
+  onResult: (result: BulkImportResult) => void;
+  onBack: () => void;
+};
+
+export function StepReview({
+  resolved,
+  brandId,
+  brandName,
+  onImport,
+  onResult,
+  onBack,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  const newCreators = resolved.filter((r) => r.type === "new");
+  const existingLinks = resolved.filter((r) => r.type === "existing");
+  const handleAdditions = existingLinks.filter(
+    (r) => r.type === "existing" && r.existingAssignmentId,
+  );
+  const newLinks = existingLinks.filter(
+    (r) => r.type === "existing" && !r.existingAssignmentId,
+  );
+
+  function handleImport() {
+    const input: BulkImportInput = {
+      brandId,
+      newCreators: newCreators.map((c) => ({
+        fullName: c.fullName,
+        email: c.email,
+        handle: c.handle,
+        startDate: c.startDate,
+      })),
+      existingCreatorLinks: existingLinks
+        .filter((c) => c.type === "existing")
+        .map((c) => ({
+          creatorId: c.creatorId,
+          handle: c.handle,
+          startDate: c.startDate,
+          existingAssignmentId: c.existingAssignmentId,
+        })),
+    };
+
+    startTransition(async () => {
+      const result = await onImport(input);
+      onResult(result);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold">{resolved.length}</p>
+          <p className="text-xs text-muted-foreground">Total</p>
+        </div>
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-green-600">{newCreators.length}</p>
+          <p className="text-xs text-muted-foreground">Novos creators</p>
+        </div>
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-blue-600">{newLinks.length}</p>
+          <p className="text-xs text-muted-foreground">Novos vínculos</p>
+        </div>
+        <div className="rounded-md border p-3 text-center">
+          <p className="text-2xl font-bold text-amber-600">{handleAdditions.length}</p>
+          <p className="text-xs text-muted-foreground">Handles adicionados</p>
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Marca: <span className="font-medium text-foreground">{brandName}</span>
+      </p>
+
+      <div className="max-h-[300px] overflow-y-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Handle</TableHead>
+              <TableHead>Data Início</TableHead>
+              <TableHead className="w-40">Ação</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {resolved.map((r, i) => (
+              <TableRow key={i}>
+                <TableCell className="font-medium">{r.fullName}</TableCell>
+                <TableCell className="font-mono text-sm">{r.handle}</TableCell>
+                <TableCell>
+                  {format(parseISO(r.startDate), "dd/MM/yyyy", { locale: ptBR })}
+                </TableCell>
+                <TableCell>
+                  {r.type === "new" ? (
+                    <Badge variant="outline" className="text-xs">
+                      <UserPlus className="mr-1 h-3 w-3" />
+                      Novo creator
+                    </Badge>
+                  ) : r.existingAssignmentId ? (
+                    <Badge variant="secondary" className="text-xs text-amber-600">
+                      <Plus className="mr-1 h-3 w-3" />
+                      Add handle
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary" className="text-xs text-blue-600">
+                      <Link className="mr-1 h-3 w-3" />
+                      Vincular
+                    </Badge>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack} disabled={isPending}>
+          Voltar
+        </Button>
+        <Button onClick={handleImport} disabled={isPending}>
+          {isPending ? "Importando..." : "Importar"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/import-csv/step-upload.tsx
+++ b/components/import-csv/step-upload.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Papa from "papaparse";
+import { parse, isValid } from "date-fns";
+import { Upload } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { csvRowSchema } from "@/lib/schemas/csv-import";
+import type { ParsedCreator } from "./types";
+
+type Brand = { id: number; name: string };
+
+type RowError = {
+  row: number;
+  field: string;
+  message: string;
+};
+
+type Props = {
+  brands: Brand[];
+  onNext: (brandId: number, creators: ParsedCreator[]) => void;
+};
+
+const REQUIRED_COLUMNS = ["nome", "handle", "data_inicio"];
+const MAX_ROWS = 100;
+
+export function StepUpload({ brands, onNext }: Props) {
+  const [brandId, setBrandId] = useState<string>("");
+  const [fileName, setFileName] = useState<string>("");
+  const [parsedCreators, setParsedCreators] = useState<ParsedCreator[]>([]);
+  const [rowErrors, setRowErrors] = useState<RowError[]>([]);
+  const [generalError, setGeneralError] = useState<string>("");
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setFileName(file.name);
+    setRowErrors([]);
+    setGeneralError("");
+    setParsedCreators([]);
+
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: (h) => h.trim().toLowerCase(),
+      complete(results) {
+        const headers = results.meta.fields ?? [];
+        const missing = REQUIRED_COLUMNS.filter((c) => !headers.includes(c));
+        if (missing.length > 0) {
+          setGeneralError(
+            `Colunas obrigatórias ausentes: ${missing.join(", ")}`,
+          );
+          return;
+        }
+
+        const rows = results.data as Record<string, string>[];
+        if (rows.length === 0) {
+          setGeneralError("Arquivo CSV vazio.");
+          return;
+        }
+        if (rows.length > MAX_ROWS) {
+          setGeneralError(
+            `Máximo de ${MAX_ROWS} linhas permitido. Este arquivo tem ${rows.length} linhas.`,
+          );
+          return;
+        }
+
+        const errors: RowError[] = [];
+        const creators: ParsedCreator[] = [];
+
+        rows.forEach((row, i) => {
+          const rowNum = i + 2; // header is row 1
+
+          const zodResult = csvRowSchema.safeParse(row);
+          if (!zodResult.success) {
+            zodResult.error.issues.forEach((issue) => {
+              errors.push({
+                row: rowNum,
+                field: String(issue.path[0] ?? ""),
+                message: issue.message,
+              });
+            });
+            return;
+          }
+
+          const dateStr = row.data_inicio?.trim();
+          const parsedDate = parse(dateStr, "dd/MM/yyyy", new Date());
+          if (!isValid(parsedDate)) {
+            errors.push({
+              row: rowNum,
+              field: "data_inicio",
+              message: `Formato inválido "${dateStr}". Use DD/MM/AAAA.`,
+            });
+            return;
+          }
+
+          const isoDate = parsedDate.toISOString().split("T")[0];
+
+          creators.push({
+            fullName: row.nome.trim(),
+            email: row.email?.trim() ?? "",
+            handle: row.handle.trim(),
+            startDate: isoDate,
+          });
+        });
+
+        setRowErrors(errors);
+        if (errors.length === 0) {
+          setParsedCreators(creators);
+        }
+      },
+      error(err) {
+        setGeneralError(`Erro ao ler CSV: ${err.message}`);
+      },
+    });
+  }
+
+  const canAdvance = brandId && parsedCreators.length > 0 && rowErrors.length === 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Marca</label>
+          <Select value={brandId} onValueChange={setBrandId}>
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione a marca" />
+            </SelectTrigger>
+            <SelectContent>
+              {brands.map((b) => (
+                <SelectItem key={b.id} value={b.id.toString()}>
+                  {b.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Arquivo CSV</label>
+          <div
+            className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-6 cursor-pointer hover:border-primary/50 transition-colors"
+            onClick={() => fileRef.current?.click()}
+          >
+            <Upload className="h-8 w-8 text-muted-foreground mb-2" />
+            <p className="text-sm text-muted-foreground">
+              {fileName || "Clique para selecionar um arquivo .csv"}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Colunas: nome, email, handle, data_inicio (DD/MM/AAAA)
+            </p>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".csv"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+          </div>
+        </div>
+      </div>
+
+      {generalError && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {generalError}
+        </div>
+      )}
+
+      {rowErrors.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-destructive">
+            {rowErrors.length} erro(s) encontrado(s):
+          </p>
+          <div className="max-h-48 overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16">Linha</TableHead>
+                  <TableHead className="w-24">Campo</TableHead>
+                  <TableHead>Erro</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rowErrors.map((err, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{err.row}</TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {err.field}
+                    </TableCell>
+                    <TableCell>{err.message}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+
+      {parsedCreators.length > 0 && rowErrors.length === 0 && (
+        <div className="rounded-md bg-muted/50 p-3 text-sm">
+          {parsedCreators.length} creator(s) encontrado(s) no arquivo.
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button
+          disabled={!canAdvance}
+          onClick={() => onNext(Number(brandId), parsedCreators)}
+        >
+          Próximo
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/import-csv/types.ts
+++ b/components/import-csv/types.ts
@@ -1,0 +1,22 @@
+import type { CreatorWithBrands } from "@/app/dashboard/creators/list/actions";
+
+export type ParsedCreator = {
+  fullName: string;
+  email: string;
+  handle: string;
+  startDate: string; // ISO YYYY-MM-DD
+};
+
+export type ResolvedCreator = ParsedCreator & (
+  | { type: "new" }
+  | { type: "existing"; creatorId: number; creatorName: string; existingAssignmentId?: number }
+);
+
+export type CreatorMatch = {
+  parsed: ParsedCreator;
+  bestMatch: CreatorWithBrands | null;
+  similarity: number;
+  decision: "new" | "existing";
+  alreadyLinked: boolean; // true if existing creator is already linked to target brand
+  existingAssignmentId?: number; // if already linked, the creator_brands.id
+};

--- a/lib/schemas/csv-import.ts
+++ b/lib/schemas/csv-import.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const csvRowSchema = z.object({
+  nome: z.string().min(1, "Nome é obrigatório"),
+  email: z.string().email("Email inválido").optional().or(z.literal("")),
+  handle: z.string().min(1, "Handle é obrigatório"),
+  data_inicio: z.string().min(1, "Data de início é obrigatória"),
+});
+
+export type CsvRow = z.infer<typeof csvRowSchema>;
+
+export const bulkImportSchema = z.object({
+  brandId: z.number(),
+  newCreators: z.array(
+    z.object({
+      fullName: z.string().min(1),
+      email: z.string().optional().or(z.literal("")),
+      handle: z.string().min(1),
+      startDate: z.string(),
+    }),
+  ),
+  existingCreatorLinks: z.array(
+    z.object({
+      creatorId: z.number(),
+      handle: z.string().min(1),
+      startDate: z.string(),
+      existingAssignmentId: z.number().optional(),
+    }),
+  ),
+});
+
+export type BulkImportInput = z.infer<typeof bulkImportSchema>;
+
+export type BulkImportResult =
+  | {
+      success: true;
+      createdCount: number;
+      linkedCount: number;
+      handleAddedCount: number;
+      errors: Array<{ name: string; error: string }>;
+    }
+  | { success: false; error: string };

--- a/lib/string-similarity.ts
+++ b/lib/string-similarity.ts
@@ -1,0 +1,40 @@
+/**
+ * Normalized Levenshtein similarity between two strings.
+ * Returns a value between 0 (completely different) and 1 (identical).
+ */
+export function stringSimilarity(a: string, b: string): number {
+  const sa = normalize(a);
+  const sb = normalize(b);
+
+  if (sa === sb) return 1;
+  if (sa.length === 0 || sb.length === 0) return 0;
+
+  const maxLen = Math.max(sa.length, sb.length);
+  return 1 - levenshtein(sa, sb) / maxLen;
+}
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a.length > b.length) [a, b] = [b, a];
+
+  let prev = Array.from({ length: a.length + 1 }, (_, i) => i);
+  let curr = new Array(a.length + 1);
+
+  for (let j = 1; j <= b.length; j++) {
+    curr[0] = j;
+    for (let i = 1; i <= a.length; i++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[i] = Math.min(
+        prev[i] + 1,
+        curr[i - 1] + 1,
+        prev[i - 1] + cost,
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[a.length];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lucide-react": "^0.511.0",
         "next": "^15",
         "next-themes": "^0.4.6",
+        "papaparse": "^5.5.3",
         "radix-ui": "^1.4.3",
         "react": "^19.0.0",
         "react-day-picker": "^9.14.0",
@@ -32,6 +33,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@types/node": "^20",
+        "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.20",
@@ -4032,6 +4034,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/phoenix": {
@@ -9574,6 +9586,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.511.0",
     "next": "^15",
     "next-themes": "^0.4.6",
+    "papaparse": "^5.5.3",
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-day-picker": "^9.14.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@types/node": "^20",
+    "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Summary
- Adds "Importar CSV" button on the Creators management page (`/dashboard/creators/list`)
- 4-step wizard dialog: upload CSV + select brand → fuzzy duplicate detection → review → import results
- Supports creating new creators, linking existing creators to new brands, and appending handles to existing brand links
- Uses Levenshtein-based name similarity (threshold 75%) for duplicate detection with user confirmation
- CSV format: `nome`, `email`, `handle`, `data_inicio` (DD/MM/AAAA), max 100 rows

## New files
- `lib/string-similarity.ts` — normalized Levenshtein distance
- `lib/schemas/csv-import.ts` — Zod schemas + types
- `components/import-csv/` — wizard steps (upload, match, review, result) + orchestrator dialog

## Modified files
- `app/dashboard/creators/list/actions.ts` — new `bulkImportCreators` server action
- `app/dashboard/creators/list/page.tsx` — renders ImportCsvDialog
- `package.json` — added `papaparse`

## Test plan
- [x] Upload valid CSV with known and unknown creators, verify duplicate detection
- [x] Confirm existing creator match → verify handle is appended (not duplicated)
- [x] Mark match as "Novo creator" → verify new creator is created
- [ ] Upload CSV with invalid dates/missing columns → verify error display
- [ ] Upload CSV with >100 rows → verify limit error
- [x] Complete import and verify creators appear in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)