### PR TITLE
Fix bulk import not splitting comma-separated handles

### DIFF
--- a/app/dashboard/creators/list/actions.ts
+++ b/app/dashboard/creators/list/actions.ts
@@ -14,6 +14,10 @@ import {
   type BulkImportResult,
 } from "@/lib/schemas/csv-import";
 
+function splitHandles(raw: string): string[] {
+  return raw.split(",").map((h) => h.trim()).filter(Boolean);
+}
+
 export type CreatorBrand = {
   id: number;
   assignmentId: number;
@@ -115,10 +119,7 @@ export async function createCreatorWithBrands(
   const creatorBrandsRows = brandAssignments.map((ba) => ({
     creator_id: creator.id,
     brand_id: Number(ba.brandId),
-    handles: ba.handles
-      .split(",")
-      .map((h) => h.trim())
-      .filter(Boolean),
+    handles: splitHandles(ba.handles),
     start_date: ba.startDate.toISOString().split("T")[0],
   }));
 
@@ -190,7 +191,7 @@ export async function updateCreator(
     const { error: updateError } = await supabase
       .from("creator_brands")
       .update({
-        handles: ba.handles.split(",").map((h) => h.trim()).filter(Boolean),
+        handles: splitHandles(ba.handles),
         start_date: ba.startDate.toISOString().split("T")[0],
       })
       .eq("id", ba.assignmentId!);
@@ -259,7 +260,7 @@ export async function bulkImportCreators(
     const brandRows = (insertedCreators ?? []).map((creator, i) => ({
       creator_id: creator.id,
       brand_id: brandId,
-      handles: [newCreators[i].handle],
+      handles: splitHandles(newCreators[i].handle),
       start_date: newCreators[i].startDate,
     }));
 
@@ -290,10 +291,12 @@ export async function bulkImportCreators(
       }
 
       const currentHandles = (current?.handles as string[]) ?? [];
-      if (!currentHandles.includes(link.handle)) {
+      const newHandles = splitHandles(link.handle);
+      const merged = [...new Set([...currentHandles, ...newHandles])];
+      if (merged.length > currentHandles.length) {
         const { error: updateErr } = await supabase
           .from("creator_brands")
-          .update({ handles: [...currentHandles, link.handle] })
+          .update({ handles: merged })
           .eq("id", link.existingAssignmentId);
 
         if (updateErr) {
@@ -309,7 +312,7 @@ export async function bulkImportCreators(
         .insert({
           creator_id: link.creatorId,
           brand_id: brandId,
-          handles: [link.handle],
+          handles: splitHandles(link.handle),
           start_date: link.startDate,
         });
 


### PR DESCRIPTION
## Summary
- Bulk CSV import was storing comma-separated handles as a single array element (`["a, b, c"]`) instead of splitting into individual elements (`["a", "b", "c"]`)
- This broke the Metabase sync query — each creator got one `ILIKE '%a, b, c%'` instead of separate `ILIKE '%a%' OR ILIKE '%b%' OR ILIKE '%c%'`
- Extracted `splitHandles()` helper and applied it consistently across `createCreatorWithBrands`, `updateCreator`, and `bulkImportCreators`
- Existing corrupted data in production was fixed via SQL UPDATE

## Test plan
- [x] Import creators via CSV with comma-separated handles and verify they are stored as separate array elements in `creator_brands.handles`
- [x] Edit a creator's handles and verify the split still works correctly
- [x] Run a sync and verify the Metabase query uses separate `ILIKE` per handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)