### PR TITLE
Add /test-local and /deploy skills, update CLAUDE.md

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,91 @@
+---
+description: Deploy Supabase migrations and Edge Functions to production with safety checks
+user_invocable: true
+---
+
+# /deploy — Production Deployment
+
+Deploy changes to production Supabase with pre-flight validation and explicit user confirmation at every destructive step.
+
+**Golden rule:** NEVER execute a remote/production command without the user saying "yes" first.
+
+## 1. Pre-flight (run /test-local)
+
+Execute the full `/test-local` checklist first.
+
+- If any **critical** check fails, STOP and report. Do not proceed to deployment.
+- If only **warnings** exist (e.g., Edge Functions), ask the user if they want to continue.
+
+## 2. Identify Pending Changes
+
+### Migrations
+
+1. Run `supabase migration list` to compare local vs remote migrations.
+2. List any migrations that exist locally but have NOT been pushed to remote.
+3. For each pending migration, show the filename and a brief description of what it does (read the migration file).
+
+### Edge Functions
+
+1. Check if any files in `supabase/functions/` have been modified since the last deploy.
+   - Use `git diff main -- supabase/functions/` to detect changes.
+2. If modified, summarize what changed.
+
+### Summary
+
+Present a clear summary:
+
+```
+Pending deployment:
+- Migrations: [N] pending (list filenames)
+- Edge Functions: [changed/no changes] (list function names if changed)
+```
+
+If nothing is pending, report "Nothing to deploy" and stop.
+
+## 3. Confirmation Gate
+
+Present the summary and ask: **"Confirm deploy to production?"**
+
+- List exactly what will be executed (`supabase db push`, `supabase functions deploy <name>`)
+- WAIT for the user to explicitly confirm before proceeding
+- If the user says no or wants to adjust, stop immediately
+
+## 4. Deploy Migrations
+
+Only if there are pending migrations AND user confirmed:
+
+```bash
+supabase db push
+```
+
+- Report success or failure.
+- If it fails, STOP. Do not proceed to Edge Functions. Show the error and suggest fixes.
+
+## 5. Deploy Edge Functions
+
+Only if Edge Functions changed AND user confirmed:
+
+```bash
+supabase functions deploy <function-name>
+```
+
+Deploy each modified function individually. Report success or failure for each.
+
+## 6. Post-deploy Verification
+
+After successful deployment:
+
+1. Check Supabase project logs for any immediate errors using `supabase` CLI or MCP tools.
+2. If the user has access to the production URL, suggest they verify the app manually.
+
+## 7. Report
+
+Present a final summary:
+
+```
+Deployment complete:
+[success/failed] Migrations pushed (N applied)
+[success/failed/skipped] Edge Functions deployed (list names)
+
+Post-deploy: [any warnings or errors from logs]
+```

--- a/.claude/skills/test-local/SKILL.md
+++ b/.claude/skills/test-local/SKILL.md
@@ -1,0 +1,74 @@
+---
+description: Run pre-flight checks to validate the local development environment before deploying
+user_invocable: true
+---
+
+# /test-local — Local Environment Validation
+
+Run each check below in order. Report results as a checklist at the end. Stop early and report if a critical step fails.
+
+## 1. Docker & Supabase Health
+
+Run `supabase status` to verify local Supabase services are running.
+
+- If services are not running, report the failure and suggest `supabase start`.
+- Do NOT start Supabase automatically — the user may need to start Docker first.
+
+**Critical:** If this fails, stop here. Nothing else works without Supabase running.
+
+## 2. Migration Sync
+
+Check for uncommitted schema changes and apply pending migrations:
+
+1. Run `supabase db diff` to detect schema drift (changes in `supabase/schemas/` not yet captured as migrations).
+   - If there is drift, warn the user and suggest running `supabase db diff -f <name>` to generate a migration.
+2. Run `supabase migration up` to apply any pending migrations to the local database.
+   - Never use Supabase MCP or direct SQL to apply migrations.
+
+## 3. Build Check
+
+Run `npm run build` to verify:
+- No TypeScript errors
+- No Next.js build errors
+- All imports resolve correctly
+
+Report the first errors found (truncate to 30 lines max if verbose).
+
+## 4. Edge Functions
+
+1. Start Edge Functions with `supabase functions serve --no-verify-jwt` in the background.
+2. Wait 3 seconds for the server to start.
+3. Invoke the function with a lightweight test payload:
+   ```bash
+   curl -s -X POST http://localhost:54321/functions/v1/sync-ad-metrics \
+     -H "Content-Type: application/json" \
+     -d '{"trigger": "test"}' | head -50
+   ```
+4. Check the response for errors. A non-2xx status or error message means failure.
+5. Stop the functions server after the test.
+
+**Non-critical:** If Edge Functions fail but the rest passes, report it as a warning (the user may not need ETL for their current work).
+
+## 5. App Verification
+
+1. Start the dev server with `npm run dev` in the background.
+2. Wait for the server to be ready (check for "Ready" in output or poll `http://localhost:3000`).
+3. Verify the app responds with HTTP 200 at `http://localhost:3000`.
+4. Stop the dev server after verification.
+
+## 6. Report
+
+Present a summary checklist:
+
+```
+Pre-flight results:
+[pass/fail] Docker & Supabase running
+[pass/fail] No schema drift
+[pass/fail] Migrations applied
+[pass/fail] Build passes
+[pass/warn/fail] Edge Functions healthy
+[pass/fail] App loads correctly
+```
+
+If all critical checks pass: "Environment is ready for deploy."
+If any critical check fails: "Fix the issues above before deploying."

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ supabase/.env
 next-env.d.ts
 
 # claude
-.claude
+.claude/*
+!.claude/skills/
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git Workflow
+
+Always create a new branch and PR for changes — never commit directly to main unless explicitly told to.
+
+## Deployment Rules
+
+Never push migrations or changes to production/remote without explicit user confirmation. Always ask before deploying.
+
 ## Projeto
 
 Plataforma interna para gestores de tráfego e acompanhadores de creators monitorarem a performance de criativos UGC vinculados a múltiplas marcas/contas de anúncio no Meta Ads. Dados originados de um banco existente de Facebook Ads consultado via Metabase API.
@@ -9,12 +17,13 @@ Plataforma interna para gestores de tráfego e acompanhadores de creators monito
 ## Stack
 
 - **Framework:** Next.js 14 com App Router (template `with-supabase`)
-- **UI:** Tailwind CSS + shadcn/ui
+- **UI:** Tailwind CSS v4 + shadcn/ui — ao adicionar componentes, garantir compatibilidade com Tailwind v4. Não misturar padrões v3 e v4.
 - **Gráficos:** Recharts
 - **Backend:** Next.js Server Actions (sem API Routes custom — Edge Functions só para ETL)
 - **Auth:** Supabase Auth — perfil único, sem diferenciação de papéis (todos os usuários autenticados têm acesso total)
 - **Banco:** Supabase (PostgreSQL) — sem Row Level Security por perfil
-- **ETL:** Job agendado que consulta Metabase API e alimenta o Supabase
+- **ETL:** Supabase Edge Functions — job agendado que consulta Metabase API e alimenta o Supabase
+- **Linguagens:** TypeScript e JavaScript. Sempre usar TypeScript para novos arquivos.
 
 ## Comandos
 
@@ -117,6 +126,7 @@ Não rastreados pelo `supabase db diff`: DML (INSERT/UPDATE/DELETE), RLS policie
 - Sempre adicionar novas colunas ao final das tabelas para evitar diffs confusos
 - Nunca resetar uma versão já deployada em produção — reverter via novo schema + novo diff
 - Configurar ordem de execução em `config.toml` via `[db.migrations] schema_paths` quando houver dependências entre tabelas
+- Usar `supabase migration up` para aplicar migrations localmente. Não aplicar migrations manualmente via Supabase MCP ou SQL direto.
 
 ## Padrões de código
 


### PR DESCRIPTION
## Summary
- Add `/test-local` skill for pre-flight local environment validation (Docker, migrations, build, Edge Functions, app)
- Add `/deploy` skill for safe production deployment with confirmation gates at every destructive step
- Update CLAUDE.md with rules from insights analysis: git workflow, deployment rules, Tailwind v4 compatibility, migration tooling
- Update .gitignore to version `.claude/skills/` while keeping other `.claude/` contents ignored

## Test plan
- [ ] Run `/test-local` and verify it executes each check step in order
- [ ] Run `/deploy` and verify it runs pre-flight, shows pending changes, and waits for confirmation before any remote action
- [ ] Verify `.claude/skills/` is tracked by git in new clones/worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)