### PR TITLE
feat: unifica gráficos da visão mensal em um único gráfico combinado

### DIFF
--- a/components/combined-spend-share-chart.tsx
+++ b/components/combined-spend-share-chart.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+} from "@/components/ui/chart";
+
+export type CombinedSpendShareDataPoint = {
+  label: string;
+  spendTotal: number;
+  spendRecentes: number;
+  sharePercentTotal: number;
+  sharePercentRecentes: number;
+};
+
+interface CombinedSpendShareChartProps {
+  data: CombinedSpendShareDataPoint[];
+  title: string;
+}
+
+const chartConfig = {
+  spendTotal: {
+    label: "Gasto Total (R$)",
+    color: "hsl(var(--chart-1))",
+  },
+  spendRecentes: {
+    label: "Gasto Recentes (R$)",
+    color: "hsl(var(--chart-3))",
+  },
+  sharePercentTotal: {
+    label: "Share Total %",
+    color: "hsl(var(--chart-2))",
+  },
+  sharePercentRecentes: {
+    label: "Share Recentes %",
+    color: "hsl(var(--chart-4))",
+  },
+} satisfies ChartConfig;
+
+function formatBRL(value: number) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatPercent(value: number) {
+  return `${value.toFixed(1)}%`;
+}
+
+const tooltipLabels: Record<string, string> = {
+  spendTotal: "Gasto Total",
+  spendRecentes: "Gasto Recentes",
+  sharePercentTotal: "Share Total",
+  sharePercentRecentes: "Share Recentes",
+};
+
+export function CombinedSpendShareChart({
+  data,
+  title,
+}: CombinedSpendShareChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium">{title}</h3>
+        <div className="flex h-[380px] items-center justify-center rounded-md border text-sm text-muted-foreground">
+          Sem dados para o período selecionado
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium">{title}</h3>
+      <ChartContainer config={chartConfig} className="h-[380px] w-full">
+        <ComposedChart data={data} barGap={2} barCategoryGap="20%">
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            fontSize={12}
+          />
+          <YAxis
+            yAxisId="left"
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={formatBRL}
+            fontSize={12}
+            width={80}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={formatPercent}
+            fontSize={12}
+            width={50}
+            domain={[0, "auto"]}
+          />
+          <ChartTooltip
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              return (
+                <div className="rounded-lg border bg-background p-2.5 text-xs shadow-xl">
+                  <p className="mb-1.5 font-medium">{label}</p>
+                  {payload.map((entry) => {
+                    const key = entry.dataKey as string;
+                    const isPercent = key.startsWith("sharePercent");
+                    return (
+                      <div
+                        key={key}
+                        className="flex items-center gap-2"
+                      >
+                        <div
+                          className="h-2.5 w-2.5 rounded-[2px]"
+                          style={{ backgroundColor: entry.color }}
+                        />
+                        <span className="text-muted-foreground">
+                          {tooltipLabels[key] ?? key}:
+                        </span>
+                        <span className="font-mono font-medium">
+                          {isPercent
+                            ? formatPercent(entry.value as number)
+                            : formatBRL(entry.value as number)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            }}
+          />
+          <ChartLegend content={<ChartLegendContent />} />
+          <Bar
+            yAxisId="left"
+            dataKey="spendTotal"
+            fill="var(--color-spendTotal)"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={36}
+          />
+          <Bar
+            yAxisId="left"
+            dataKey="spendRecentes"
+            fill="var(--color-spendRecentes)"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={36}
+          />
+          <Line
+            yAxisId="right"
+            dataKey="sharePercentTotal"
+            type="monotone"
+            stroke="var(--color-sharePercentTotal)"
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            yAxisId="right"
+            dataKey="sharePercentRecentes"
+            type="monotone"
+            stroke="var(--color-sharePercentRecentes)"
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+        </ComposedChart>
+      </ChartContainer>
+    </div>
+  );
+}

--- a/components/monthly-view-charts.tsx
+++ b/components/monthly-view-charts.tsx
@@ -22,9 +22,9 @@ import {
   type DatePreset,
 } from "@/components/date-period-selector";
 import {
-  SpendShareChart,
-  type SpendShareDataPoint,
-} from "@/components/spend-share-chart";
+  CombinedSpendShareChart,
+  type CombinedSpendShareDataPoint,
+} from "@/components/combined-spend-share-chart";
 import { getMonthlySpendView, getCreatorsByBrand, type MonthlySpendRow } from "@/app/dashboard/monthly-view/actions";
 
 type Brand = { id: number; name: string };
@@ -60,19 +60,24 @@ const monthlyPresets: DatePreset[] = [
   },
 ];
 
-function toChartData(
+function toCombinedChartData(
   rows: MonthlySpendRow[],
-  spendKey: "spend_total" | "spend_recentes",
-): SpendShareDataPoint[] {
+): CombinedSpendShareDataPoint[] {
   return rows.map((row) => {
-    const spend = Number(row[spendKey]) || 0;
+    const spendTotal = Number(row.spend_total) || 0;
+    const spendRecentes = Number(row.spend_recentes) || 0;
     const brandTotal = Number(row.brand_total_spend) || 0;
-    const sharePercent = brandTotal > 0 ? (spend / brandTotal) * 100 : 0;
     const date = new Date(row.month + "T00:00:00");
     return {
       label: format(date, "MMM/yy", { locale: ptBR }),
-      spend,
-      sharePercent: Math.round(sharePercent * 10) / 10,
+      spendTotal,
+      spendRecentes,
+      sharePercentTotal:
+        brandTotal > 0 ? Math.round((spendTotal / brandTotal) * 1000) / 10 : 0,
+      sharePercentRecentes:
+        brandTotal > 0
+          ? Math.round((spendRecentes / brandTotal) * 1000) / 10
+          : 0,
     };
   });
 }
@@ -150,8 +155,7 @@ export function MonthlyViewCharts({
     }
   }
 
-  const totalChartData = toChartData(data, "spend_total");
-  const recentesChartData = toChartData(data, "spend_recentes");
+  const combinedChartData = toCombinedChartData(data);
 
   return (
     <div className="space-y-6">
@@ -188,21 +192,12 @@ export function MonthlyViewCharts({
       />
 
       {isPending ? (
-        <div className="space-y-6">
-          <Skeleton className="h-[340px] w-full" />
-          <Skeleton className="h-[340px] w-full" />
-        </div>
+        <Skeleton className="h-[420px] w-full" />
       ) : (
-        <div className="space-y-8">
-          <SpendShareChart
-            data={totalChartData}
-            title="Gasto total em creators"
-          />
-          <SpendShareChart
-            data={recentesChartData}
-            title="Gasto em conteúdo recente de creators"
-          />
-        </div>
+        <CombinedSpendShareChart
+          data={combinedChartData}
+          title="Gasto em creators: total vs. recentes"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Unifica os dois gráficos separados da visão mensal (gasto total + gasto recentes) em um único gráfico combinado
- Novo componente `CombinedSpendShareChart` com 2 barras (gasto total vs. recentes) e 2 linhas (share % total vs. recentes)
- `SpendShareChart` mantido intacto — daily-view não é afetado

## Test plan
- [ ] Verificar que `/dashboard/monthly-view` exibe o gráfico combinado com 4 séries
- [ ] Verificar que o tooltip mostra os 4 valores corretamente
- [ ] Verificar que `/dashboard/daily-view` continua funcionando normalmente
- [ ] `npm run build` passa sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)