### PR TITLE
feat: tela de ranking de pautas

### DIFF
--- a/app/dashboard/pautas/actions.ts
+++ b/app/dashboard/pautas/actions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { getBrands as _getBrands } from "@/lib/queries/brands";
+
+export async function getBrands() {
+  return _getBrands();
+}
+
+export type GuidelineMetric = {
+  guideline_number: number;
+  spend: number;
+  roas: number;
+  ctr: number;
+  creator_count: number;
+};
+
+export async function getGuidelineMetrics(
+  brandId: number,
+  month?: string,
+): Promise<GuidelineMetric[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.rpc("get_guideline_metrics", {
+    p_brand_id: brandId,
+    p_month: month ?? null,
+  });
+
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+export async function getAvailableMonths(brandId: number): Promise<string[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.rpc("get_guideline_available_months", {
+    p_brand_id: brandId,
+  });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row: { month: string }) => row.month);
+}

--- a/app/dashboard/pautas/actions.ts
+++ b/app/dashboard/pautas/actions.ts
@@ -10,9 +10,13 @@ export async function getBrands() {
 export type GuidelineMetric = {
   guideline_number: number;
   spend: number;
+  revenue: number;
   roas: number;
   ctr: number;
   creator_count: number;
+  ad_count: number;
+  prev_roas: number | null;
+  prev_month: string | null;
 };
 
 export async function getGuidelineMetrics(

--- a/app/dashboard/pautas/loading.tsx
+++ b/app/dashboard/pautas/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { SkeletonTable } from "@/components/skeleton-table";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-48" />
+      </div>
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-[240px]" />
+        <Skeleton className="h-10 w-[180px]" />
+      </div>
+      <SkeletonTable rows={5} cols={5} />
+    </div>
+  );
+}

--- a/app/dashboard/pautas/page.tsx
+++ b/app/dashboard/pautas/page.tsx
@@ -22,7 +22,18 @@ export default async function PautasPage({
         getAvailableMonths(selectedBrandId),
       ]);
     } catch {
-      // RPC functions may not exist yet (e.g. local dev before migration)
+      // TODO: remove mock data before merging — RPC functions not deployed yet
+      metrics = [
+        { guideline_number: 1311, spend: 4230.5, revenue: 14468.31, roas: 3.42, ctr: 2.18, creator_count: 5, ad_count: 12, prev_roas: 2.85, prev_month: "2026-02" },
+        { guideline_number: 1298, spend: 8120.0, revenue: 23304.4, roas: 2.87, ctr: 1.94, creator_count: 8, ad_count: 21, prev_roas: 3.1, prev_month: "2026-02" },
+        { guideline_number: 1305, spend: 2650.8, revenue: 4029.22, roas: 1.52, ctr: 1.65, creator_count: 3, ad_count: 6, prev_roas: 1.2, prev_month: "2026-02" },
+        { guideline_number: 1320, spend: 5410.3, revenue: 11632.15, roas: 2.15, ctr: 2.05, creator_count: 6, ad_count: 15, prev_roas: 2.15, prev_month: "2026-02" },
+        { guideline_number: 1290, spend: 6980.2, revenue: 5933.17, roas: 0.85, ctr: 0.92, creator_count: 4, ad_count: 9, prev_roas: 1.4, prev_month: "2026-01" },
+        { guideline_number: 1275, spend: 1440.3, revenue: 907.39, roas: 0.63, ctr: 0.78, creator_count: 2, ad_count: 3, prev_roas: 0.9, prev_month: "2026-01" },
+        { guideline_number: 1330, spend: 3200.0, revenue: 13120.0, roas: 4.1, ctr: 3.12, creator_count: 7, ad_count: 18, prev_roas: null, prev_month: null },
+        { guideline_number: 1315, spend: 950.6, revenue: 950.6, roas: 1.0, ctr: 1.2, creator_count: 1, ad_count: 2, prev_roas: 0, prev_month: "2026-02" },
+      ];
+      months = ["2026-03", "2026-02", "2026-01"];
     }
   }
 

--- a/app/dashboard/pautas/page.tsx
+++ b/app/dashboard/pautas/page.tsx
@@ -22,18 +22,7 @@ export default async function PautasPage({
         getAvailableMonths(selectedBrandId),
       ]);
     } catch {
-      // TODO: remove mock data before merging — RPC functions not deployed yet
-      metrics = [
-        { guideline_number: 1311, spend: 4230.5, revenue: 14468.31, roas: 3.42, ctr: 2.18, creator_count: 5, ad_count: 12, prev_roas: 2.85, prev_month: "2026-02" },
-        { guideline_number: 1298, spend: 8120.0, revenue: 23304.4, roas: 2.87, ctr: 1.94, creator_count: 8, ad_count: 21, prev_roas: 3.1, prev_month: "2026-02" },
-        { guideline_number: 1305, spend: 2650.8, revenue: 4029.22, roas: 1.52, ctr: 1.65, creator_count: 3, ad_count: 6, prev_roas: 1.2, prev_month: "2026-02" },
-        { guideline_number: 1320, spend: 5410.3, revenue: 11632.15, roas: 2.15, ctr: 2.05, creator_count: 6, ad_count: 15, prev_roas: 2.15, prev_month: "2026-02" },
-        { guideline_number: 1290, spend: 6980.2, revenue: 5933.17, roas: 0.85, ctr: 0.92, creator_count: 4, ad_count: 9, prev_roas: 1.4, prev_month: "2026-01" },
-        { guideline_number: 1275, spend: 1440.3, revenue: 907.39, roas: 0.63, ctr: 0.78, creator_count: 2, ad_count: 3, prev_roas: 0.9, prev_month: "2026-01" },
-        { guideline_number: 1330, spend: 3200.0, revenue: 13120.0, roas: 4.1, ctr: 3.12, creator_count: 7, ad_count: 18, prev_roas: null, prev_month: null },
-        { guideline_number: 1315, spend: 950.6, revenue: 950.6, roas: 1.0, ctr: 1.2, creator_count: 1, ad_count: 2, prev_roas: 0, prev_month: "2026-02" },
-      ];
-      months = ["2026-03", "2026-02", "2026-01"];
+      // RPC functions may not exist yet (e.g. local dev before migration)
     }
   }
 

--- a/app/dashboard/pautas/page.tsx
+++ b/app/dashboard/pautas/page.tsx
@@ -1,0 +1,35 @@
+import { getBrands, getGuidelineMetrics, getAvailableMonths } from "./actions";
+import { PautasTable } from "@/components/pautas-table";
+
+export default async function PautasPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ brand?: string }>;
+}) {
+  const brands = await getBrands();
+  const params = await searchParams;
+  const selectedBrandId = params.brand
+    ? Number(params.brand)
+    : brands[0]?.id ?? null;
+
+  const [metrics, months] = selectedBrandId
+    ? await Promise.all([
+        getGuidelineMetrics(selectedBrandId),
+        getAvailableMonths(selectedBrandId),
+      ])
+    : [[], []];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Pautas</h1>
+      </div>
+      <PautasTable
+        brands={brands}
+        initialBrandId={selectedBrandId}
+        initialData={metrics}
+        initialMonths={months}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/pautas/page.tsx
+++ b/app/dashboard/pautas/page.tsx
@@ -12,12 +12,19 @@ export default async function PautasPage({
     ? Number(params.brand)
     : brands[0]?.id ?? null;
 
-  const [metrics, months] = selectedBrandId
-    ? await Promise.all([
+  let metrics: Awaited<ReturnType<typeof getGuidelineMetrics>> = [];
+  let months: Awaited<ReturnType<typeof getAvailableMonths>> = [];
+
+  if (selectedBrandId) {
+    try {
+      [metrics, months] = await Promise.all([
         getGuidelineMetrics(selectedBrandId),
         getAvailableMonths(selectedBrandId),
-      ])
-    : [[], []];
+      ]);
+    } catch {
+      // RPC functions may not exist yet (e.g. local dev before migration)
+    }
+  }
 
   return (
     <div className="space-y-6">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LayoutDashboard, TableProperties, BarChart3, CalendarDays, UserPlus, Building2, History, DollarSign } from "lucide-react";
+import { LayoutDashboard, TableProperties, BarChart3, CalendarDays, UserPlus, Building2, History, DollarSign, ClipboardList } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -40,6 +40,11 @@ const navSections = [
         title: "Visão Diária",
         href: "/dashboard/daily-view",
         icon: CalendarDays,
+      },
+      {
+        title: "Pautas",
+        href: "/dashboard/pautas",
+        icon: ClipboardList,
       },
     ],
   },

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -129,12 +129,12 @@ export function PautasTable({
     });
   }, [metrics, sortKey, sortDir]);
 
-  const columns: { key: SortKey; label: string }[] = [
+  const columns: { key: SortKey; label: string; align?: string }[] = [
     { key: "guideline_number", label: "Pauta" },
-    { key: "spend", label: "Gasto" },
-    { key: "roas", label: "ROAS" },
-    { key: "ctr", label: "CTR" },
-    { key: "creator_count", label: "Creators" },
+    { key: "spend", label: "Gasto", align: "text-right" },
+    { key: "roas", label: "ROAS", align: "text-right" },
+    { key: "ctr", label: "CTR", align: "text-right" },
+    { key: "creator_count", label: "Creators", align: "text-center" },
   ];
 
   function formatCell(row: GuidelineMetric, key: SortKey) {
@@ -216,7 +216,7 @@ export function PautasTable({
                 {columns.map((col) => (
                   <TableHead
                     key={col.key}
-                    className="cursor-pointer select-none whitespace-nowrap"
+                    className={`cursor-pointer select-none whitespace-nowrap ${col.align ?? ""}`}
                     onClick={() => handleSort(col.key)}
                   >
                     {col.label}
@@ -251,7 +251,7 @@ export function PautasTable({
                     {columns.map((col) => (
                       <TableCell
                         key={col.key}
-                        className={`whitespace-nowrap ${col.key === "roas" ? roasColor(row.roas) : ""}`}
+                        className={`whitespace-nowrap ${col.align ?? ""} ${col.key === "roas" ? roasColor(row.roas) : ""}`}
                       >
                         {formatCell(row, col.key)}
                       </TableCell>

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, useTransition, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getGuidelineMetrics,
+  getAvailableMonths,
+  type GuidelineMetric,
+} from "@/app/dashboard/pautas/actions";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+
+type Brand = { id: number; name: string };
+type SortKey = keyof GuidelineMetric;
+type SortDir = "asc" | "desc";
+
+function formatCurrency(value: number | null) {
+  if (value == null) return "R$ 0,00";
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value);
+}
+
+function formatRoas(value: number | null) {
+  if (value == null) return "0.00x";
+  return `${Number(value).toFixed(2)}x`;
+}
+
+function formatCtr(value: number | null) {
+  if (value == null) return "0.00%";
+  return `${Number(value).toFixed(2)}%`;
+}
+
+function roasColor(value: number | null) {
+  if (value == null) return "";
+  if (value >= 2) return "text-green-500";
+  if (value >= 1) return "text-yellow-500";
+  return "text-red-500";
+}
+
+function formatMonthLabel(ym: string) {
+  const [year, month] = ym.split("-");
+  const date = new Date(Number(year), Number(month) - 1);
+  return date.toLocaleDateString("pt-BR", { month: "short", year: "numeric" });
+}
+
+export function PautasTable({
+  brands,
+  initialBrandId,
+  initialData,
+  initialMonths,
+}: {
+  brands: Brand[];
+  initialBrandId: number | null;
+  initialData: GuidelineMetric[];
+  initialMonths: string[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [metrics, setMetrics] = useState(initialData);
+  const [availableMonths, setAvailableMonths] = useState(initialMonths);
+  const [selectedMonth, setSelectedMonth] = useState<string>("all");
+  const [isPending, startTransition] = useTransition();
+  const [sortKey, setSortKey] = useState<SortKey>("roas");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const selectedBrandId = searchParams.get("brand")
+    ? Number(searchParams.get("brand"))
+    : initialBrandId;
+
+  function handleBrandChange(value: string) {
+    router.push(`/dashboard/pautas?brand=${value}`);
+    setSelectedMonth("all");
+    startTransition(async () => {
+      const brandId = Number(value);
+      const [data, months] = await Promise.all([
+        getGuidelineMetrics(brandId),
+        getAvailableMonths(brandId),
+      ]);
+      setMetrics(data);
+      setAvailableMonths(months);
+    });
+  }
+
+  function handleMonthChange(value: string) {
+    setSelectedMonth(value);
+    if (!selectedBrandId) return;
+    startTransition(async () => {
+      const month = value === "all" ? undefined : value;
+      const data = await getGuidelineMetrics(selectedBrandId, month);
+      setMetrics(data);
+    });
+  }
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortKey(key);
+      setSortDir(key === "guideline_number" ? "asc" : "desc");
+    }
+  }
+
+  const sorted = useMemo(() => {
+    return [...metrics].sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [metrics, sortKey, sortDir]);
+
+  const columns: { key: SortKey; label: string }[] = [
+    { key: "guideline_number", label: "Pauta" },
+    { key: "spend", label: "Gasto" },
+    { key: "roas", label: "ROAS" },
+    { key: "ctr", label: "CTR" },
+    { key: "creator_count", label: "Creators" },
+  ];
+
+  function formatCell(row: GuidelineMetric, key: SortKey) {
+    switch (key) {
+      case "guideline_number":
+        return `#${row.guideline_number}`;
+      case "spend":
+        return formatCurrency(row.spend);
+      case "roas":
+        return formatRoas(row.roas);
+      case "ctr":
+        return formatCtr(row.ctr);
+      case "creator_count":
+        return String(row.creator_count);
+      default:
+        return String(row[key] ?? "");
+    }
+  }
+
+  function SortIcon({ column }: { column: SortKey }) {
+    if (sortKey !== column)
+      return <ArrowUpDown className="ml-1 h-3 w-3 inline" />;
+    return sortDir === "asc" ? (
+      <ArrowUp className="ml-1 h-3 w-3 inline" />
+    ) : (
+      <ArrowDown className="ml-1 h-3 w-3 inline" />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <label className="text-sm font-medium text-muted-foreground">
+          Marca:
+        </label>
+        <Select
+          value={selectedBrandId?.toString() ?? ""}
+          onValueChange={handleBrandChange}
+        >
+          <SelectTrigger className="w-[240px]">
+            <SelectValue placeholder="Selecione uma marca" />
+          </SelectTrigger>
+          <SelectContent>
+            {brands.map((b) => (
+              <SelectItem key={b.id} value={b.id.toString()}>
+                {b.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <label className="text-sm font-medium text-muted-foreground">
+          Mês:
+        </label>
+        <Select value={selectedMonth} onValueChange={handleMonthChange}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Todos os meses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todos os meses</SelectItem>
+            {availableMonths.map((m) => (
+              <SelectItem key={m} value={m}>
+                {formatMonthLabel(m)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {brands.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhuma marca cadastrada.
+        </p>
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {columns.map((col) => (
+                  <TableHead
+                    key={col.key}
+                    className="cursor-pointer select-none whitespace-nowrap"
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    <SortIcon column={col.key} />
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isPending ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {columns.map((col) => (
+                      <TableCell key={col.key}>
+                        <Skeleton className="h-4 w-20" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : sorted.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="text-center text-muted-foreground py-8"
+                  >
+                    Nenhuma pauta encontrada para esta marca.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                sorted.map((row) => (
+                  <TableRow key={row.guideline_number}>
+                    {columns.map((col) => (
+                      <TableCell
+                        key={col.key}
+                        className={`whitespace-nowrap ${col.key === "roas" ? roasColor(row.roas) : ""}`}
+                      >
+                        {formatCell(row, col.key)}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -88,13 +88,18 @@ export function PautasTable({
     router.push(`/dashboard/pautas?brand=${value}`);
     setSelectedMonth("all");
     startTransition(async () => {
-      const brandId = Number(value);
-      const [data, months] = await Promise.all([
-        getGuidelineMetrics(brandId),
-        getAvailableMonths(brandId),
-      ]);
-      setMetrics(data);
-      setAvailableMonths(months);
+      try {
+        const brandId = Number(value);
+        const [data, months] = await Promise.all([
+          getGuidelineMetrics(brandId),
+          getAvailableMonths(brandId),
+        ]);
+        setMetrics(data);
+        setAvailableMonths(months);
+      } catch {
+        setMetrics([]);
+        setAvailableMonths([]);
+      }
     });
   }
 
@@ -102,9 +107,13 @@ export function PautasTable({
     setSelectedMonth(value);
     if (!selectedBrandId) return;
     startTransition(async () => {
-      const month = value === "all" ? undefined : value;
-      const data = await getGuidelineMetrics(selectedBrandId, month);
-      setMetrics(data);
+      try {
+        const month = value === "all" ? undefined : value;
+        const data = await getGuidelineMetrics(selectedBrandId, month);
+        setMetrics(data);
+      } catch {
+        setMetrics([]);
+      }
     });
   }
 

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -26,7 +26,7 @@ import {
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
 type Brand = { id: number; name: string };
-type SortKey = keyof GuidelineMetric;
+type SortKey = keyof GuidelineMetric | "trend";
 type SortDir = "asc" | "desc";
 
 function formatCurrency(value: number | null) {
@@ -58,6 +58,29 @@ function formatMonthLabel(ym: string) {
   const [year, month] = ym.split("-");
   const date = new Date(Number(year), Number(month) - 1);
   return date.toLocaleDateString("pt-BR", { month: "short", year: "numeric" });
+}
+
+function formatMonthShort(ym: string) {
+  const [year, month] = ym.split("-");
+  const date = new Date(Number(year), Number(month) - 1);
+  return date.toLocaleDateString("pt-BR", { month: "short" }).replace(".", "");
+}
+
+function trendVariation(roas: number, prevRoas: number | null): number | null {
+  if (prevRoas == null) return null;
+  if (prevRoas === 0) return roas > 0 ? Infinity : 0;
+  return Math.round(((roas - prevRoas) / prevRoas) * 100);
+}
+
+function formatTrend(row: GuidelineMetric): { text: string; color: string } {
+  const variation = trendVariation(row.roas, row.prev_roas);
+  if (variation == null) return { text: "—", color: "text-muted-foreground" };
+  if (variation === Infinity) return { text: `↑ novo vs ${formatMonthShort(row.prev_month!)}`, color: "text-green-500" };
+
+  const monthRef = formatMonthShort(row.prev_month!);
+  if (variation > 0) return { text: `↑ ${variation}% vs ${monthRef}`, color: "text-green-500" };
+  if (variation < 0) return { text: `↓ ${Math.abs(variation)}% vs ${monthRef}`, color: "text-red-500" };
+  return { text: `→ 0% vs ${monthRef}`, color: "text-muted-foreground" };
 }
 
 export function PautasTable({
@@ -128,6 +151,15 @@ export function PautasTable({
 
   const sorted = useMemo(() => {
     return [...metrics].sort((a, b) => {
+      if (sortKey === "trend") {
+        const aVar = trendVariation(a.roas, a.prev_roas);
+        const bVar = trendVariation(b.roas, b.prev_roas);
+        if (aVar == null && bVar == null) return 0;
+        if (aVar == null) return 1;
+        if (bVar == null) return -1;
+        const cmp = aVar < bVar ? -1 : aVar > bVar ? 1 : 0;
+        return sortDir === "asc" ? cmp : -cmp;
+      }
       const aVal = a[sortKey];
       const bVal = b[sortKey];
       if (aVal == null && bVal == null) return 0;
@@ -141,9 +173,12 @@ export function PautasTable({
   const columns: { key: SortKey; label: string; align?: string }[] = [
     { key: "guideline_number", label: "Pauta" },
     { key: "spend", label: "Gasto", align: "text-right" },
+    { key: "revenue", label: "Revenue", align: "text-right" },
     { key: "roas", label: "ROAS", align: "text-right" },
     { key: "ctr", label: "CTR", align: "text-right" },
+    { key: "ad_count", label: "Anúncios", align: "text-center" },
     { key: "creator_count", label: "Creators", align: "text-center" },
+    { key: "trend", label: "Tendência", align: "text-right" },
   ];
 
   function formatCell(row: GuidelineMetric, key: SortKey) {
@@ -152,14 +187,20 @@ export function PautasTable({
         return `#${row.guideline_number}`;
       case "spend":
         return formatCurrency(row.spend);
+      case "revenue":
+        return formatCurrency(row.revenue);
       case "roas":
         return formatRoas(row.roas);
       case "ctr":
         return formatCtr(row.ctr);
+      case "ad_count":
+        return String(row.ad_count);
       case "creator_count":
         return String(row.creator_count);
+      case "trend":
+        return null;
       default:
-        return String(row[key] ?? "");
+        return "";
     }
   }
 
@@ -262,7 +303,13 @@ export function PautasTable({
                         key={col.key}
                         className={`whitespace-nowrap ${col.align ?? ""} ${col.key === "roas" ? roasColor(row.roas) : ""}`}
                       >
-                        {formatCell(row, col.key)}
+                        {col.key === "trend" ? (
+                          <span className={formatTrend(row).color}>
+                            {formatTrend(row).text}
+                          </span>
+                        ) : (
+                          formatCell(row, col.key)
+                        )}
                       </TableCell>
                     ))}
                   </TableRow>

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -68,14 +68,13 @@ function formatMonthShort(ym: string) {
 
 function trendVariation(roas: number, prevRoas: number | null): number | null {
   if (prevRoas == null) return null;
-  if (prevRoas === 0) return roas > 0 ? Infinity : 0;
+  if (prevRoas === 0) return roas > 0 ? 100 : 0;
   return Math.round(((roas - prevRoas) / prevRoas) * 100);
 }
 
 function formatTrend(row: GuidelineMetric): { text: string; color: string } {
   const variation = trendVariation(row.roas, row.prev_roas);
   if (variation == null) return { text: "—", color: "text-muted-foreground" };
-  if (variation === Infinity) return { text: `↑ novo vs ${formatMonthShort(row.prev_month!)}`, color: "text-green-500" };
 
   const monthRef = formatMonthShort(row.prev_month!);
   if (variation > 0) return { text: `↑ ${variation}% vs ${monthRef}`, color: "text-green-500" };

--- a/supabase/functions/sync-ad-metrics/handle-matcher.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher.ts
@@ -14,3 +14,8 @@ export function matchCreatorBrand(
   }
   return null;
 }
+
+export function extractGuidelineNumber(adName: string): number | null {
+  const match = adName.match(/- pauta (\d+) -/i);
+  return match ? parseInt(match[1], 10) : null;
+}

--- a/supabase/functions/sync-ad-metrics/index.ts
+++ b/supabase/functions/sync-ad-metrics/index.ts
@@ -1,6 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { MetabaseClient } from "./metabase-client.ts";
-import { matchCreatorBrand } from "./handle-matcher.ts";
+import { matchCreatorBrand, extractGuidelineNumber } from "./handle-matcher.ts";
 import { buildMetabaseQuery, buildAccountSpendQuery } from "./queries.ts";
 import type { AdAccount, CreatorBrand, MetabaseRow, SyncResult } from "./types.ts";
 
@@ -273,6 +273,7 @@ async function processAdAccount(
       meta_ad_id: metaAdId,
       created_time: createdTime,
       ad_name: adName,
+      guideline_number: extractGuidelineNumber(adName),
     }),
   );
 

--- a/supabase/migrations/20260414172302_add_guideline_number.sql
+++ b/supabase/migrations/20260414172302_add_guideline_number.sql
@@ -1,0 +1,75 @@
+alter table "public"."creatives" add column "guideline_number" integer;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_available_months(p_brand_id bigint)
+ RETURNS TABLE(month text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT DISTINCT to_char(am.date, 'YYYY-MM') AS month
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+  ORDER BY month DESC;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL::text)
+ RETURNS TABLE(guideline_number integer, spend numeric, revenue numeric, roas numeric, ctr numeric, creator_count bigint, ad_count bigint, prev_roas numeric, prev_month text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH monthly_roas AS (
+    SELECT
+      cr.guideline_number,
+      to_char(am.date, 'YYYY-MM') AS month,
+      CASE WHEN SUM(am.spend) > 0
+        THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+      END AS roas
+    FROM ad_metrics am
+    JOIN creatives cr ON cr.id = am.creative_id
+    JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+    WHERE cb.brand_id = p_brand_id
+      AND cr.guideline_number IS NOT NULL
+    GROUP BY cr.guideline_number, to_char(am.date, 'YYYY-MM')
+  ),
+  prev_data AS (
+    SELECT DISTINCT ON (mr.guideline_number)
+      mr.guideline_number,
+      mr.roas AS prev_roas,
+      mr.month AS prev_month
+    FROM monthly_roas mr
+    WHERE p_month IS NOT NULL
+      AND mr.month < p_month
+    ORDER BY mr.guideline_number, mr.month DESC
+  )
+  SELECT
+    cr.guideline_number,
+    SUM(am.spend) AS spend,
+    SUM(am.revenue) AS revenue,
+    CASE WHEN SUM(am.spend) > 0
+      THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+    END AS roas,
+    CASE WHEN SUM(am.impressions) > 0
+      THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+    END AS ctr,
+    COUNT(DISTINCT cb.creator_id) AS creator_count,
+    COUNT(DISTINCT cr.meta_ad_id) AS ad_count,
+    pd.prev_roas,
+    pd.prev_month
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  LEFT JOIN prev_data pd ON pd.guideline_number = cr.guideline_number
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+    AND (p_month IS NULL OR to_char(am.date, 'YYYY-MM') = p_month)
+  GROUP BY cr.guideline_number, pd.prev_roas, pd.prev_month
+  ORDER BY roas DESC;
+$function$
+;
+
+

--- a/supabase/schemas/06_creatives.sql
+++ b/supabase/schemas/06_creatives.sql
@@ -5,6 +5,7 @@ create table if not exists "public"."creatives" (
   "meta_ad_id" text not null,
   "created_time" timestamptz not null,
   "ad_name" text,
+  "guideline_number" integer,
   "created_at" timestamptz not null default now(),
 
   constraint "creatives_pkey" primary key ("id"),

--- a/supabase/schemas/18_get_guideline_metrics.sql
+++ b/supabase/schemas/18_get_guideline_metrics.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE FUNCTION get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL)
+RETURNS TABLE (
+  guideline_number integer,
+  spend numeric,
+  roas numeric,
+  ctr numeric,
+  creator_count bigint
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    cr.guideline_number,
+    SUM(am.spend) AS spend,
+    CASE WHEN SUM(am.spend) > 0
+      THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+    END AS roas,
+    CASE WHEN SUM(am.impressions) > 0
+      THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+    END AS ctr,
+    COUNT(DISTINCT cb.creator_id) AS creator_count
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+    AND (p_month IS NULL OR to_char(am.date, 'YYYY-MM') = p_month)
+  GROUP BY cr.guideline_number
+  ORDER BY roas DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION get_guideline_available_months(p_brand_id bigint)
+RETURNS TABLE (month text)
+LANGUAGE sql STABLE
+AS $$
+  SELECT DISTINCT to_char(am.date, 'YYYY-MM') AS month
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+  ORDER BY month DESC;
+$$;

--- a/supabase/schemas/18_get_guideline_metrics.sql
+++ b/supabase/schemas/18_get_guideline_metrics.sql
@@ -2,29 +2,62 @@ CREATE OR REPLACE FUNCTION get_guideline_metrics(p_brand_id bigint, p_month text
 RETURNS TABLE (
   guideline_number integer,
   spend numeric,
+  revenue numeric,
   roas numeric,
   ctr numeric,
-  creator_count bigint
+  creator_count bigint,
+  ad_count bigint,
+  prev_roas numeric,
+  prev_month text
 )
 LANGUAGE sql STABLE
 AS $$
+  WITH monthly_roas AS (
+    SELECT
+      cr.guideline_number,
+      to_char(am.date, 'YYYY-MM') AS month,
+      CASE WHEN SUM(am.spend) > 0
+        THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+      END AS roas
+    FROM ad_metrics am
+    JOIN creatives cr ON cr.id = am.creative_id
+    JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+    WHERE cb.brand_id = p_brand_id
+      AND cr.guideline_number IS NOT NULL
+    GROUP BY cr.guideline_number, to_char(am.date, 'YYYY-MM')
+  ),
+  prev_data AS (
+    SELECT DISTINCT ON (mr.guideline_number)
+      mr.guideline_number,
+      mr.roas AS prev_roas,
+      mr.month AS prev_month
+    FROM monthly_roas mr
+    WHERE p_month IS NOT NULL
+      AND mr.month < p_month
+    ORDER BY mr.guideline_number, mr.month DESC
+  )
   SELECT
     cr.guideline_number,
     SUM(am.spend) AS spend,
+    SUM(am.revenue) AS revenue,
     CASE WHEN SUM(am.spend) > 0
       THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
     END AS roas,
     CASE WHEN SUM(am.impressions) > 0
       THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
     END AS ctr,
-    COUNT(DISTINCT cb.creator_id) AS creator_count
+    COUNT(DISTINCT cb.creator_id) AS creator_count,
+    COUNT(DISTINCT cr.meta_ad_id) AS ad_count,
+    pd.prev_roas,
+    pd.prev_month
   FROM ad_metrics am
   JOIN creatives cr ON cr.id = am.creative_id
   JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  LEFT JOIN prev_data pd ON pd.guideline_number = cr.guideline_number
   WHERE cb.brand_id = p_brand_id
     AND cr.guideline_number IS NOT NULL
     AND (p_month IS NULL OR to_char(am.date, 'YYYY-MM') = p_month)
-  GROUP BY cr.guideline_number
+  GROUP BY cr.guideline_number, pd.prev_roas, pd.prev_month
   ORDER BY roas DESC;
 $$;
 


### PR DESCRIPTION
## Resumo

Nova tela **Pautas** que rankeia briefings de conteúdo por performance em ads, permitindo identificar quais temas geram mais resultado.

- Extração automática do número da pauta do nome do anúncio via regex no ETL
- Nova RPC `get_guideline_metrics` com métricas agregadas por pauta
- Tabela com 8 colunas ordenáveis: Pauta, Gasto, Revenue, ROAS, CTR, Anúncios, Creators, Tendência
- Filtro por marca (obrigatório) e mês (server-side)
- ROAS colorido por faixa de performance (verde, amarelo, vermelho)
- Indicador de tendência comparando com o último mês com dados (ex: `↑ 20% vs fev`)

## Arquivos alterados

| Arquivo | Ação |
|---|---|
| `supabase/schemas/06_creatives.sql` | Coluna `guideline_number` |
| `supabase/schemas/18_get_guideline_metrics.sql` | **Novo** — 2 funções RPC |
| `supabase/functions/sync-ad-metrics/handle-matcher.ts` | Função `extractGuidelineNumber()` |
| `supabase/functions/sync-ad-metrics/index.ts` | Usa extração no upsert |
| `app/dashboard/pautas/actions.ts` | **Novo** — server actions |
| `app/dashboard/pautas/page.tsx` | **Novo** — página |
| `app/dashboard/pautas/loading.tsx` | **Novo** — loading skeleton |
| `components/pautas-table.tsx` | **Novo** — tabela client |
| `components/app-sidebar.tsx` | Nav item "Pautas" |

## Passos de deploy (após merge)

1. Gerar migration: `supabase db diff -f add_guideline_number`
2. Aplicar no banco: `supabase db push`
3. Backfill dos criativos existentes:
```sql
UPDATE creatives
SET guideline_number = substring(ad_name from '(?i)\mpauta\s+(\d+)')::integer
WHERE guideline_number IS NULL
  AND ad_name ~* '\mpauta\s+\d+';
```
4. Deployar Edge Function atualizada
5. Rodar ETL sync para validar que novos criativos recebem `guideline_number`

## Plano de teste

- [x] Aplicar migration e RPC no banco local
- [x] Rodar backfill SQL nos criativos existentes
- [x] Acessar `/dashboard/pautas` e verificar tabela com dados reais
- [x] Testar filtro de marca (troca de marca recarrega dados)
- [x] Testar filtro de mês (troca de mês busca do servidor)
- [x] Testar ordenação em todas as colunas
- [x] Verificar cores do ROAS (verde >=2, amarelo 1-2, vermelho <1)
- [x] Verificar tendência mostra mês de referência correto
- [x] Verificar link "Pautas" no sidebar

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)