### PR TITLE
fix(pautas): broaden guideline number regex

### DIFF
--- a/supabase/functions/sync-ad-metrics/handle-matcher.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher.ts
@@ -16,6 +16,6 @@ export function matchCreatorBrand(
 }
 
 export function extractGuidelineNumber(adName: string): number | null {
-  const match = adName.match(/- pauta (\d+) -/i);
+  const match = adName.match(/\bpauta\s+(\d+)/i);
   return match ? parseInt(match[1], 10) : null;
 }


### PR DESCRIPTION
## Summary

- Regex de extração do número da pauta era restrita demais (`- pauta (\d+) -`), exigindo hífens ao redor
- 33 criativos com "pauta" no nome não estavam sendo categorizados (ex: `PAUTA 502 JOY...`, `FEV BLACK25 PAUTA 913 TOTE...`)
- Nova regex `\bpauta\s+(\d+)` usa word boundary, cobrindo todos os padrões sem quebrar os existentes

## Test plan

- [x] Deployar Edge Function atualizada
- [x] Rodar backfill SQL com nova regex nos criativos existentes
- [x] Verificar que criativos previamente categorizados mantêm o `guideline_number`

🤖 Generated with [Claude Code](https://claude.com/claude-code)