### PR TITLE
feat(pautas): filtro multi-select de pautas

### DIFF
--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -304,7 +304,7 @@ export function PautasTable({
                     >
                       <Checkbox
                         checked={selectedGuidelines.has(num)}
-                        className="mr-2"
+                        className="mr-2 pointer-events-none"
                       />
                       #{num}
                     </CommandItem>

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -277,6 +277,55 @@ export function PautasTable({
             ))}
           </SelectContent>
         </Select>
+
+        <label className="text-sm font-medium text-muted-foreground">
+          Pautas:
+        </label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="w-[200px] justify-start font-normal">
+              {selectedGuidelines.size === 0
+                ? "Todas as pautas"
+                : `${selectedGuidelines.size} selecionada${selectedGuidelines.size > 1 ? "s" : ""}`}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[240px] p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Buscar pauta..." />
+              <CommandList>
+                <CommandEmpty>Nenhuma pauta encontrada.</CommandEmpty>
+                <CommandGroup>
+                  {availableGuidelines.map((num) => (
+                    <CommandItem
+                      key={num}
+                      value={String(num)}
+                      onSelect={() => toggleGuideline(num)}
+                      className="cursor-pointer"
+                    >
+                      <Checkbox
+                        checked={selectedGuidelines.has(num)}
+                        className="mr-2"
+                      />
+                      #{num}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+              {selectedGuidelines.size > 0 && (
+                <div className="border-t p-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setSelectedGuidelines(new Set())}
+                  >
+                    Limpar seleção
+                  </Button>
+                </div>
+              )}
+            </Command>
+          </PopoverContent>
+        </Popover>
       </div>
 
       {brands.length === 0 ? (

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -18,6 +18,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
 import {
   getGuidelineMetrics,
   getAvailableMonths,
@@ -101,14 +105,30 @@ export function PautasTable({
   const [isPending, startTransition] = useTransition();
   const [sortKey, setSortKey] = useState<SortKey>("roas");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [selectedGuidelines, setSelectedGuidelines] = useState<Set<number>>(new Set());
 
   const selectedBrandId = searchParams.get("brand")
     ? Number(searchParams.get("brand"))
     : initialBrandId;
 
+  const availableGuidelines = useMemo(
+    () => metrics.map((m) => m.guideline_number).sort((a, b) => a - b),
+    [metrics],
+  );
+
+  function toggleGuideline(num: number) {
+    setSelectedGuidelines((prev) => {
+      const next = new Set(prev);
+      if (next.has(num)) next.delete(num);
+      else next.add(num);
+      return next;
+    });
+  }
+
   function handleBrandChange(value: string) {
     router.push(`/dashboard/pautas?brand=${value}`);
     setSelectedMonth("all");
+    setSelectedGuidelines(new Set());
     startTransition(async () => {
       try {
         const brandId = Number(value);
@@ -127,6 +147,7 @@ export function PautasTable({
 
   function handleMonthChange(value: string) {
     setSelectedMonth(value);
+    setSelectedGuidelines(new Set());
     if (!selectedBrandId) return;
     startTransition(async () => {
       try {
@@ -149,7 +170,12 @@ export function PautasTable({
   }
 
   const sorted = useMemo(() => {
-    return [...metrics].sort((a, b) => {
+    const filtered =
+      selectedGuidelines.size === 0
+        ? metrics
+        : metrics.filter((m) => selectedGuidelines.has(m.guideline_number));
+
+    return [...filtered].sort((a, b) => {
       if (sortKey === "trend") {
         const aVar = trendVariation(a.roas, a.prev_roas);
         const bVar = trendVariation(b.roas, b.prev_roas);
@@ -167,7 +193,7 @@ export function PautasTable({
       const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
       return sortDir === "asc" ? cmp : -cmp;
     });
-  }, [metrics, sortKey, sortDir]);
+  }, [metrics, sortKey, sortDir, selectedGuidelines]);
 
   const columns: { key: SortKey; label: string; align?: string }[] = [
     { key: "guideline_number", label: "Pauta" },


### PR DESCRIPTION
## Resumo

Novo filtro multi-select na tela de Pautas que permite selecionar várias pautas específicas para analisar. O filtro opera **client-side** sobre os dados já carregados, sem impacto no backend.

## Funcionalidades

- **Novo filtro "Pautas:"** ao lado dos filtros de marca e mês
- Botão mostra **"Todas as pautas"** (padrão) ou **"N selecionadas"** quando há seleção
- Popover com:
  - Campo de **busca** por número de pauta
  - Lista de **checkboxes** (uma por pauta)
  - Botão **"Limpar seleção"** no rodapé (aparece quando há pelo menos uma selecionada)
- **Reset automático** ao trocar de marca ou mês (evita seleção inválida em datasets diferentes)
- Sem seleção = mostra todas as pautas (comportamento atual)
- Com seleção = tabela mostra apenas as pautas marcadas

## Arquivo alterado

| Arquivo | Ação |
|---|---|
| `components/pautas-table.tsx` | Adicionado state, helpers, lógica de filtro e UI multi-select |

Nenhuma mudança em banco, RPC ou server actions — tudo client-side.

## Commits

- `fdb5f14` — feat(pautas): add selectedGuidelines state and filter logic
- `deff610` — feat(pautas): add multi-select guideline filter UI
- `31f3913` — fix(pautas): prevent double-toggle on checkbox click

## Plano de teste

- [ ] Acessar `/dashboard/pautas` e verificar que o filtro "Pautas" aparece ao lado do filtro de mês
- [ ] Botão mostra "Todas as pautas" inicialmente
- [ ] Clicar abre popover com busca e lista de checkboxes
- [ ] Digitar no campo de busca filtra a lista
- [ ] Selecionar pautas atualiza o botão ("N selecionadas") e filtra a tabela
- [ ] Botão "Limpar seleção" aparece quando há seleção e limpa todas
- [ ] Trocar de marca reseta a seleção para "Todas as pautas"
- [ ] Trocar de mês reseta a seleção para "Todas as pautas"
- [ ] Clicar no checkbox da linha (não só no texto) toggla corretamente sem duplo-toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)