### PR TITLE
feat: Visão de Produtos (extração, exibição e filtros por produto)

### DIFF
--- a/app/dashboard/creators/actions.ts
+++ b/app/dashboard/creators/actions.ts
@@ -29,6 +29,7 @@ export type CreatorMetric = {
   ctr_recentes: number;
   cost: number | null;
   yearly_spend: number;
+  product_names: string | null;
 };
 
 export type GroupOption = {

--- a/app/dashboard/creators/actions.ts
+++ b/app/dashboard/creators/actions.ts
@@ -16,9 +16,12 @@ export async function getBrands() {
   return _getBrands();
 }
 
+export type CreatorViewMode = "creator" | "product" | "granular";
+
 export type CreatorMetric = {
-  creator: string;
-  creator_brand_id: number;
+  creator: string | null;
+  creator_brand_id: number | null;
+  product_name: string | null;
   month: string;
   group_id: number | null;
   spend_total: number;
@@ -28,8 +31,7 @@ export type CreatorMetric = {
   roas_recentes: number;
   ctr_recentes: number;
   cost: number | null;
-  yearly_spend: number;
-  product_names: string | null;
+  yearly_spend: number | null;
 };
 
 export type GroupOption = {
@@ -88,11 +90,13 @@ export async function getCreatorBrandsForBrand(
 
 export async function getCreatorMetrics(
   brandId: number,
+  viewMode: CreatorViewMode = "creator",
 ): Promise<CreatorMetric[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase.rpc("get_creator_metrics", {
     p_brand_id: brandId,
+    p_view_mode: viewMode,
   });
 
   if (error) throw new Error(error.message);

--- a/app/dashboard/daily-view/actions.ts
+++ b/app/dashboard/daily-view/actions.ts
@@ -85,8 +85,8 @@ export async function getDailySpendView(params: {
     p_creator_ids: parsed.data.creatorIds ?? null,
     p_start_date: parsed.data.startDate,
     p_end_date: parsed.data.endDate,
-    p_product_names: params.productNames && params.productNames.length > 0
-      ? params.productNames
+    p_product_names: parsed.data.productNames && parsed.data.productNames.length > 0
+      ? parsed.data.productNames
       : null,
   });
 

--- a/app/dashboard/daily-view/actions.ts
+++ b/app/dashboard/daily-view/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { spendViewFiltersSchema } from "@/lib/schemas/spend-view";
 import { getCreatorsByBrand as _getCreatorsByBrand } from "@/lib/queries/creators";
+import { getDistinctProducts as _getDistinctProducts } from "@/lib/queries/products";
 
 export async function getCreatorsByBrand(brandId: number) {
   return _getCreatorsByBrand(brandId);
@@ -71,6 +72,7 @@ export async function getDailySpendView(params: {
   creatorIds?: number[];
   startDate: string;
   endDate: string;
+  productNames?: string[];
 }): Promise<DailySpendRow[]> {
   const parsed = spendViewFiltersSchema.safeParse(params);
   if (!parsed.success) {
@@ -83,8 +85,15 @@ export async function getDailySpendView(params: {
     p_creator_ids: parsed.data.creatorIds ?? null,
     p_start_date: parsed.data.startDate,
     p_end_date: parsed.data.endDate,
+    p_product_names: params.productNames && params.productNames.length > 0
+      ? params.productNames
+      : null,
   });
 
   if (error) throw new Error(error.message);
   return data ?? [];
+}
+
+export async function getDistinctProducts(brandId: number): Promise<string[]> {
+  return _getDistinctProducts(brandId);
 }

--- a/app/dashboard/monthly-view/actions.ts
+++ b/app/dashboard/monthly-view/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { spendViewFiltersSchema } from "@/lib/schemas/spend-view";
 import { getCreatorsByBrand as _getCreatorsByBrand } from "@/lib/queries/creators";
+import { getDistinctProducts as _getDistinctProducts } from "@/lib/queries/products";
 
 export async function getCreatorsByBrand(brandId: number) {
   return _getCreatorsByBrand(brandId);
@@ -71,6 +72,7 @@ export async function getMonthlySpendView(params: {
   creatorIds?: number[];
   startDate: string;
   endDate: string;
+  productNames?: string[];
 }): Promise<MonthlySpendRow[]> {
   const parsed = spendViewFiltersSchema.safeParse(params);
   if (!parsed.success) {
@@ -83,8 +85,15 @@ export async function getMonthlySpendView(params: {
     p_creator_ids: parsed.data.creatorIds ?? null,
     p_start_date: parsed.data.startDate,
     p_end_date: parsed.data.endDate,
+    p_product_names: params.productNames && params.productNames.length > 0
+      ? params.productNames
+      : null,
   });
 
   if (error) throw new Error(error.message);
   return data ?? [];
+}
+
+export async function getDistinctProducts(brandId: number): Promise<string[]> {
+  return _getDistinctProducts(brandId);
 }

--- a/app/dashboard/monthly-view/actions.ts
+++ b/app/dashboard/monthly-view/actions.ts
@@ -85,8 +85,8 @@ export async function getMonthlySpendView(params: {
     p_creator_ids: parsed.data.creatorIds ?? null,
     p_start_date: parsed.data.startDate,
     p_end_date: parsed.data.endDate,
-    p_product_names: params.productNames && params.productNames.length > 0
-      ? params.productNames
+    p_product_names: parsed.data.productNames && parsed.data.productNames.length > 0
+      ? parsed.data.productNames
       : null,
   });
 

--- a/app/dashboard/pautas/actions.ts
+++ b/app/dashboard/pautas/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { getBrands as _getBrands } from "@/lib/queries/brands";
+import { getDistinctProducts as _getDistinctProducts } from "@/lib/queries/products";
 
 export async function getBrands() {
   return _getBrands();
@@ -23,12 +24,15 @@ export type GuidelineMetric = {
 export async function getGuidelineMetrics(
   brandId: number,
   month?: string,
+  productNames?: string[],
 ): Promise<GuidelineMetric[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase.rpc("get_guideline_metrics", {
     p_brand_id: brandId,
     p_month: month ?? null,
+    p_product_names:
+      productNames && productNames.length > 0 ? productNames : null,
   });
 
   if (error) throw new Error(error.message);
@@ -44,4 +48,8 @@ export async function getAvailableMonths(brandId: number): Promise<string[]> {
 
   if (error) throw new Error(error.message);
   return (data ?? []).map((row: { month: string }) => row.month);
+}
+
+export async function getDistinctProducts(brandId: number): Promise<string[]> {
+  return _getDistinctProducts(brandId);
 }

--- a/app/dashboard/pautas/actions.ts
+++ b/app/dashboard/pautas/actions.ts
@@ -17,6 +17,7 @@ export type GuidelineMetric = {
   ad_count: number;
   prev_roas: number | null;
   prev_month: string | null;
+  product_names: string | null;
 };
 
 export async function getGuidelineMetrics(

--- a/app/dashboard/pautas/page.tsx
+++ b/app/dashboard/pautas/page.tsx
@@ -1,4 +1,9 @@
-import { getBrands, getGuidelineMetrics, getAvailableMonths } from "./actions";
+import {
+  getBrands,
+  getGuidelineMetrics,
+  getAvailableMonths,
+  getDistinctProducts,
+} from "./actions";
 import { PautasTable } from "@/components/pautas-table";
 
 export default async function PautasPage({
@@ -14,15 +19,17 @@ export default async function PautasPage({
 
   let metrics: Awaited<ReturnType<typeof getGuidelineMetrics>> = [];
   let months: Awaited<ReturnType<typeof getAvailableMonths>> = [];
+  let products: string[] = [];
 
   if (selectedBrandId) {
     try {
-      [metrics, months] = await Promise.all([
+      [metrics, months, products] = await Promise.all([
         getGuidelineMetrics(selectedBrandId),
         getAvailableMonths(selectedBrandId),
+        getDistinctProducts(selectedBrandId),
       ]);
-    } catch {
-      // RPC functions may not exist yet (e.g. local dev before migration)
+    } catch (err) {
+      console.error("Failed to load pautas dashboard data:", err);
     }
   }
 
@@ -36,6 +43,7 @@ export default async function PautasPage({
         initialBrandId={selectedBrandId}
         initialData={metrics}
         initialMonths={months}
+        initialProducts={products}
       />
     </div>
   );

--- a/components/creators-table.tsx
+++ b/components/creators-table.tsx
@@ -17,14 +17,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   getCreatorMetrics,
   getGroupsByBrand,
   type CreatorMetric,
+  type CreatorViewMode,
   type GroupOption,
 } from "@/app/dashboard/creators/actions";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { toast } from "sonner";
 import { InlineEditCost } from "@/components/inline-edit-cost";
 
 type Brand = { id: number; name: string };
@@ -54,6 +57,45 @@ function formatMonth(dateStr: string) {
   return date.toLocaleDateString("pt-BR", { month: "short", year: "numeric", timeZone: "UTC" });
 }
 
+const COLUMNS_BY_MODE: Record<
+  CreatorViewMode,
+  { key: SortKey; label: string; sortable?: boolean }[]
+> = {
+  creator: [
+    { key: "month", label: "Mês/Ano" },
+    { key: "creator", label: "Creator" },
+    { key: "cost", label: "Custo" },
+    { key: "yearly_spend", label: "Investimento Ano" },
+    { key: "spend_total", label: "Gasto" },
+    { key: "roas_total", label: "ROAS" },
+    { key: "ctr_total", label: "CTR" },
+    { key: "spend_recentes", label: "Gasto Recentes" },
+    { key: "roas_recentes", label: "ROAS Recentes" },
+    { key: "ctr_recentes", label: "CTR Recentes" },
+  ],
+  product: [
+    { key: "month", label: "Mês/Ano" },
+    { key: "product_name", label: "Produto" },
+    { key: "spend_total", label: "Gasto" },
+    { key: "roas_total", label: "ROAS" },
+    { key: "ctr_total", label: "CTR" },
+    { key: "spend_recentes", label: "Gasto Recentes" },
+    { key: "roas_recentes", label: "ROAS Recentes" },
+    { key: "ctr_recentes", label: "CTR Recentes" },
+  ],
+  granular: [
+    { key: "month", label: "Mês/Ano" },
+    { key: "creator", label: "Creator" },
+    { key: "product_name", label: "Produto" },
+    { key: "spend_total", label: "Gasto" },
+    { key: "roas_total", label: "ROAS" },
+    { key: "ctr_total", label: "CTR" },
+    { key: "spend_recentes", label: "Gasto Recentes" },
+    { key: "roas_recentes", label: "ROAS Recentes" },
+    { key: "ctr_recentes", label: "CTR Recentes" },
+  ],
+};
+
 export function CreatorsTable({
   brands,
   initialBrandId,
@@ -67,6 +109,7 @@ export function CreatorsTable({
   const searchParams = useSearchParams();
   const [metrics, setMetrics] = useState(initialMetrics);
   const [isPending, startTransition] = useTransition();
+  const [viewMode, setViewMode] = useState<CreatorViewMode>("creator");
   const [sortKey, setSortKey] = useState<SortKey>("creator");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [selectedMonth, setSelectedMonth] = useState<string>("all");
@@ -79,7 +122,7 @@ export function CreatorsTable({
 
   useEffect(() => {
     if (selectedBrandId) {
-      getGroupsByBrand(selectedBrandId).then(setGroups);
+      getGroupsByBrand(selectedBrandId).then(setGroups).catch(() => setGroups([]));
     } else {
       setGroups([]);
     }
@@ -90,14 +133,34 @@ export function CreatorsTable({
     return unique.sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
   }, [metrics]);
 
+  function reload(brandId: number, mode: CreatorViewMode) {
+    startTransition(async () => {
+      try {
+        const data = await getCreatorMetrics(brandId, mode);
+        setMetrics(data);
+      } catch {
+        toast.error("Erro ao carregar dados da Tabela Mensal");
+        setMetrics([]);
+      }
+    });
+  }
+
   function handleBrandChange(value: string) {
     router.push(`/dashboard/creators?brand=${value}`);
     setSelectedMonth("all");
     setSelectedGroupId("all");
-    startTransition(async () => {
-      const data = await getCreatorMetrics(Number(value));
-      setMetrics(data);
-    });
+    reload(Number(value), viewMode);
+  }
+
+  function handleViewModeChange(value: string) {
+    if (!value || value === viewMode) return;
+    const mode = value as CreatorViewMode;
+    setViewMode(mode);
+    setSortKey(mode === "product" ? "product_name" : "creator");
+    setSortDir("asc");
+    setSelectedMonth("all");
+    setSelectedGroupId("all");
+    if (selectedBrandId) reload(selectedBrandId, mode);
   }
 
   function handleSort(key: SortKey) {
@@ -105,7 +168,7 @@ export function CreatorsTable({
       setSortDir(sortDir === "asc" ? "desc" : "asc");
     } else {
       setSortKey(key);
-      setSortDir(key === "creator" ? "asc" : "desc");
+      setSortDir(key === "creator" || key === "product_name" ? "asc" : "desc");
     }
   }
 
@@ -115,12 +178,14 @@ export function CreatorsTable({
     );
   }
 
+  const columns = COLUMNS_BY_MODE[viewMode];
+
   const sorted = useMemo(() => {
     let filtered = selectedMonth === "all"
       ? metrics
       : metrics.filter((m) => m.month === selectedMonth);
 
-    if (selectedGroupId !== "all") {
+    if (viewMode === "creator" && selectedGroupId !== "all") {
       if (selectedGroupId === "none") {
         filtered = filtered.filter((m) => m.group_id == null);
       } else {
@@ -137,7 +202,7 @@ export function CreatorsTable({
       const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
       return sortDir === "asc" ? cmp : -cmp;
     });
-  }, [metrics, sortKey, sortDir, selectedMonth, selectedGroupId]);
+  }, [metrics, sortKey, sortDir, selectedMonth, selectedGroupId, viewMode]);
 
   function SortIcon({ column }: { column: SortKey }) {
     if (sortKey !== column) return <ArrowUpDown className="ml-1 h-3 w-3 inline" />;
@@ -148,32 +213,19 @@ export function CreatorsTable({
     );
   }
 
-  const columns: { key: SortKey; label: string; sortable?: boolean }[] = [
-    { key: "month", label: "Mês/Ano" },
-    { key: "creator", label: "Creator" },
-    { key: "product_names", label: "Produto", sortable: false },
-    { key: "cost", label: "Custo" },
-    { key: "yearly_spend", label: "Investimento Ano" },
-    { key: "spend_total", label: "Gasto" },
-    { key: "roas_total", label: "ROAS" },
-    { key: "ctr_total", label: "CTR" },
-    { key: "spend_recentes", label: "Gasto Recentes" },
-    { key: "roas_recentes", label: "ROAS Recentes" },
-    { key: "ctr_recentes", label: "CTR Recentes" },
-  ];
-
   function formatCell(row: CreatorMetric, key: SortKey) {
     switch (key) {
       case "month":
         return formatMonth(row.month);
       case "creator":
-        return row.creator;
-      case "product_names":
-        return row.product_names ?? "Não informado";
+        return row.creator ?? "—";
+      case "product_name":
+        return row.product_name ?? "Não informado";
       case "spend_total":
       case "spend_recentes":
-      case "yearly_spend":
         return formatCurrency(row[key] as number);
+      case "yearly_spend":
+        return row.yearly_spend == null ? "—" : formatCurrency(row.yearly_spend);
       case "roas_total":
       case "roas_recentes":
         return formatRoas(row[key] as number);
@@ -183,6 +235,15 @@ export function CreatorsTable({
       default:
         return String(row[key] ?? "");
     }
+  }
+
+  function rowKey(row: CreatorMetric, i: number) {
+    return [
+      row.month,
+      row.creator_brand_id ?? "—",
+      row.product_name ?? "—",
+      i,
+    ].join("|");
   }
 
   return (
@@ -205,7 +266,20 @@ export function CreatorsTable({
           </SelectContent>
         </Select>
 
-        {groups.length > 0 && (
+        <label className="text-sm font-medium text-muted-foreground">Visão:</label>
+        <ToggleGroup
+          type="single"
+          value={viewMode}
+          onValueChange={handleViewModeChange}
+          variant="outline"
+          size="sm"
+        >
+          <ToggleGroupItem value="creator">Por Creator</ToggleGroupItem>
+          <ToggleGroupItem value="product">Por Produto</ToggleGroupItem>
+          <ToggleGroupItem value="granular">Granular</ToggleGroupItem>
+        </ToggleGroup>
+
+        {viewMode === "creator" && groups.length > 0 && (
           <>
             <label className="text-sm font-medium text-muted-foreground">Grupo:</label>
             <Select
@@ -285,10 +359,10 @@ export function CreatorsTable({
                 </TableRow>
               ) : (
                 sorted.map((row, i) => (
-                  <TableRow key={`${row.creator}-${row.month}-${i}`}>
+                  <TableRow key={rowKey(row, i)}>
                     {columns.map((col) => (
                       <TableCell key={col.key} className="whitespace-nowrap">
-                        {col.key === "cost" ? (
+                        {col.key === "cost" && viewMode === "creator" && row.creator_brand_id != null ? (
                           <InlineEditCost
                             value={row.cost}
                             creatorBrandId={row.creator_brand_id}

--- a/components/creators-table.tsx
+++ b/components/creators-table.tsx
@@ -148,9 +148,10 @@ export function CreatorsTable({
     );
   }
 
-  const columns: { key: SortKey; label: string }[] = [
+  const columns: { key: SortKey; label: string; sortable?: boolean }[] = [
     { key: "month", label: "Mês/Ano" },
     { key: "creator", label: "Creator" },
+    { key: "product_names", label: "Produto", sortable: false },
     { key: "cost", label: "Custo" },
     { key: "yearly_spend", label: "Investimento Ano" },
     { key: "spend_total", label: "Gasto" },
@@ -167,16 +168,18 @@ export function CreatorsTable({
         return formatMonth(row.month);
       case "creator":
         return row.creator;
+      case "product_names":
+        return row.product_names ?? "Não informado";
       case "spend_total":
       case "spend_recentes":
       case "yearly_spend":
-        return formatCurrency(row[key]);
+        return formatCurrency(row[key] as number);
       case "roas_total":
       case "roas_recentes":
-        return formatRoas(row[key]);
+        return formatRoas(row[key] as number);
       case "ctr_total":
       case "ctr_recentes":
-        return formatCtr(row[key]);
+        return formatCtr(row[key] as number);
       default:
         return String(row[key] ?? "");
     }
@@ -254,11 +257,11 @@ export function CreatorsTable({
                 {columns.map((col) => (
                   <TableHead
                     key={col.key}
-                    className="cursor-pointer select-none whitespace-nowrap"
-                    onClick={() => handleSort(col.key)}
+                    className={`${col.sortable === false ? "" : "cursor-pointer"} select-none whitespace-nowrap`}
+                    onClick={() => { if (col.sortable !== false) handleSort(col.key); }}
                   >
                     {col.label}
-                    <SortIcon column={col.key} />
+                    {col.sortable !== false && <SortIcon column={col.key} />}
                   </TableHead>
                 ))}
               </TableRow>

--- a/components/daily-view-charts.tsx
+++ b/components/daily-view-charts.tsx
@@ -178,12 +178,8 @@ export function DailyViewCharts({
     setSelectedProduct("all");
     router.push(`/dashboard/daily-view?brand=${brandId}`);
     startTransition(async () => {
-      const [newCreators, newProducts] = await Promise.all([
-        getCreatorsByBrand(brandId),
-        getDistinctProducts(brandId),
-      ]);
+      const newCreators = await getCreatorsByBrand(brandId);
       setCreators(newCreators);
-      setProducts(newProducts);
       const allIds = newCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
       const [rows, brandGoals] = await Promise.all([

--- a/components/daily-view-charts.tsx
+++ b/components/daily-view-charts.tsx
@@ -25,6 +25,7 @@ import {
   SpendShareChart,
   type SpendShareDataPoint,
 } from "@/components/spend-share-chart";
+import { toast } from "sonner";
 import { getDailySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, getDistinctProducts, type DailySpendRow, type GroupOption } from "@/app/dashboard/daily-view/actions";
 import { getGoalsForBrand, type BrandGoalRow } from "@/app/dashboard/brands/actions";
 
@@ -129,8 +130,15 @@ export function DailyViewCharts({
 
   useEffect(() => {
     if (selectedBrandId) {
-      getGroupsByBrand(selectedBrandId).then(setGroups);
-      getDistinctProducts(selectedBrandId).then(setProducts);
+      Promise.all([
+        getGroupsByBrand(selectedBrandId),
+        getDistinctProducts(selectedBrandId),
+      ])
+        .then(([grps, prods]) => {
+          setGroups(grps);
+          setProducts(prods);
+        })
+        .catch(() => toast.error("Erro ao carregar filtros"));
     } else {
       setGroups([]);
       setProducts([]);

--- a/components/daily-view-charts.tsx
+++ b/components/daily-view-charts.tsx
@@ -25,7 +25,7 @@ import {
   SpendShareChart,
   type SpendShareDataPoint,
 } from "@/components/spend-share-chart";
-import { getDailySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, type DailySpendRow, type GroupOption } from "@/app/dashboard/daily-view/actions";
+import { getDailySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, getDistinctProducts, type DailySpendRow, type GroupOption } from "@/app/dashboard/daily-view/actions";
 import { getGoalsForBrand, type BrandGoalRow } from "@/app/dashboard/brands/actions";
 
 type Brand = { id: number; name: string };
@@ -124,25 +124,31 @@ export function DailyViewCharts({
   const [goals, setGoals] = useState<BrandGoalRow[]>(initialGoals);
   const [groups, setGroups] = useState<GroupOption[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("all");
+  const [products, setProducts] = useState<string[]>([]);
+  const [selectedProduct, setSelectedProduct] = useState<string>("all");
 
   useEffect(() => {
     if (selectedBrandId) {
       getGroupsByBrand(selectedBrandId).then(setGroups);
+      getDistinctProducts(selectedBrandId).then(setProducts);
     } else {
       setGroups([]);
+      setProducts([]);
     }
   }, [selectedBrandId]);
 
   const fetchData = useCallback(
-    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }) => {
+    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, product: string) => {
       startTransition(async () => {
         const allSelected = creatorIds.length === 0;
+        const productNames = product === "all" ? undefined : [product];
         const [rows, brandGoals] = await Promise.all([
           getDailySpendView({
             brandId,
             creatorIds: allSelected ? undefined : creatorIds,
             startDate: format(range.from, "yyyy-MM-dd"),
             endDate: format(range.to, "yyyy-MM-dd"),
+            productNames,
           }),
           getGoalsForBrand(
             brandId,
@@ -161,10 +167,15 @@ export function DailyViewCharts({
     const brandId = Number(value);
     setSelectedBrandId(brandId);
     setSelectedGroupId("all");
+    setSelectedProduct("all");
     router.push(`/dashboard/daily-view?brand=${brandId}`);
     startTransition(async () => {
-      const newCreators = await getCreatorsByBrand(brandId);
+      const [newCreators, newProducts] = await Promise.all([
+        getCreatorsByBrand(brandId),
+        getDistinctProducts(brandId),
+      ]);
       setCreators(newCreators);
+      setProducts(newProducts);
       const allIds = newCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
       const [rows, brandGoals] = await Promise.all([
@@ -195,12 +206,14 @@ export function DailyViewCharts({
       setCreators(filteredCreators);
       const allIds = filteredCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
+      const productNames = selectedProduct === "all" ? undefined : [selectedProduct];
       const [rows, brandGoals] = await Promise.all([
         getDailySpendView({
           brandId: selectedBrandId,
           creatorIds: allIds.length > 0 ? allIds : undefined,
           startDate: format(dateRange.from, "yyyy-MM-dd"),
           endDate: format(dateRange.to, "yyyy-MM-dd"),
+          productNames,
         }),
         getGoalsForBrand(
           selectedBrandId,
@@ -213,17 +226,24 @@ export function DailyViewCharts({
     });
   }
 
+  function handleProductChange(value: string) {
+    setSelectedProduct(value);
+    if (selectedBrandId) {
+      fetchData(selectedBrandId, selectedCreatorIds, dateRange, value);
+    }
+  }
+
   function handleCreatorChange(ids: number[]) {
     setSelectedCreatorIds(ids);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, ids, dateRange);
+      fetchData(selectedBrandId, ids, dateRange, selectedProduct);
     }
   }
 
   function handleDateChange(range: { from: Date; to: Date }) {
     setDateRange(range);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, range);
+      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProduct);
     }
   }
 
@@ -275,6 +295,22 @@ export function DailyViewCharts({
           onSelectionChange={handleCreatorChange}
           disabled={isPending}
         />
+
+        {products.length > 0 && (
+          <Select value={selectedProduct} onValueChange={handleProductChange}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Todos os produtos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os produtos</SelectItem>
+              {products.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
       <DatePeriodSelector

--- a/components/monthly-view-charts.tsx
+++ b/components/monthly-view-charts.tsx
@@ -25,6 +25,7 @@ import {
   SpendShareChart,
   type SpendShareDataPoint,
 } from "@/components/spend-share-chart";
+import { toast } from "sonner";
 import { getMonthlySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, getDistinctProducts, type MonthlySpendRow, type GroupOption } from "@/app/dashboard/monthly-view/actions";
 import { getGoalsForBrand, type BrandGoalRow } from "@/app/dashboard/brands/actions";
 
@@ -118,8 +119,15 @@ export function MonthlyViewCharts({
 
   useEffect(() => {
     if (selectedBrandId) {
-      getGroupsByBrand(selectedBrandId).then(setGroups);
-      getDistinctProducts(selectedBrandId).then(setProducts);
+      Promise.all([
+        getGroupsByBrand(selectedBrandId),
+        getDistinctProducts(selectedBrandId),
+      ])
+        .then(([grps, prods]) => {
+          setGroups(grps);
+          setProducts(prods);
+        })
+        .catch(() => toast.error("Erro ao carregar filtros"));
     } else {
       setGroups([]);
       setProducts([]);

--- a/components/monthly-view-charts.tsx
+++ b/components/monthly-view-charts.tsx
@@ -167,12 +167,8 @@ export function MonthlyViewCharts({
     setSelectedProduct("all");
     router.push(`/dashboard/monthly-view?brand=${brandId}`);
     startTransition(async () => {
-      const [newCreators, newProducts] = await Promise.all([
-        getCreatorsByBrand(brandId),
-        getDistinctProducts(brandId),
-      ]);
+      const newCreators = await getCreatorsByBrand(brandId);
       setCreators(newCreators);
-      setProducts(newProducts);
       const allIds = newCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
       const [rows, brandGoals] = await Promise.all([

--- a/components/monthly-view-charts.tsx
+++ b/components/monthly-view-charts.tsx
@@ -25,7 +25,7 @@ import {
   SpendShareChart,
   type SpendShareDataPoint,
 } from "@/components/spend-share-chart";
-import { getMonthlySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, type MonthlySpendRow, type GroupOption } from "@/app/dashboard/monthly-view/actions";
+import { getMonthlySpendView, getCreatorsByBrand, getGroupsByBrand, getCreatorsByBrandAndGroup, getDistinctProducts, type MonthlySpendRow, type GroupOption } from "@/app/dashboard/monthly-view/actions";
 import { getGoalsForBrand, type BrandGoalRow } from "@/app/dashboard/brands/actions";
 
 type Brand = { id: number; name: string };
@@ -113,25 +113,31 @@ export function MonthlyViewCharts({
   const [goals, setGoals] = useState<BrandGoalRow[]>(initialGoals);
   const [groups, setGroups] = useState<GroupOption[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("all");
+  const [products, setProducts] = useState<string[]>([]);
+  const [selectedProduct, setSelectedProduct] = useState<string>("all");
 
   useEffect(() => {
     if (selectedBrandId) {
       getGroupsByBrand(selectedBrandId).then(setGroups);
+      getDistinctProducts(selectedBrandId).then(setProducts);
     } else {
       setGroups([]);
+      setProducts([]);
     }
   }, [selectedBrandId]);
 
   const fetchData = useCallback(
-    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }) => {
+    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, product: string) => {
       startTransition(async () => {
         const allSelected = creatorIds.length === 0;
+        const productNames = product === "all" ? undefined : [product];
         const [rows, brandGoals] = await Promise.all([
           getMonthlySpendView({
             brandId,
             creatorIds: allSelected ? undefined : creatorIds,
             startDate: format(range.from, "yyyy-MM-dd"),
             endDate: format(range.to, "yyyy-MM-dd"),
+            productNames,
           }),
           getGoalsForBrand(
             brandId,
@@ -150,10 +156,15 @@ export function MonthlyViewCharts({
     const brandId = Number(value);
     setSelectedBrandId(brandId);
     setSelectedGroupId("all");
+    setSelectedProduct("all");
     router.push(`/dashboard/monthly-view?brand=${brandId}`);
     startTransition(async () => {
-      const newCreators = await getCreatorsByBrand(brandId);
+      const [newCreators, newProducts] = await Promise.all([
+        getCreatorsByBrand(brandId),
+        getDistinctProducts(brandId),
+      ]);
       setCreators(newCreators);
+      setProducts(newProducts);
       const allIds = newCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
       const [rows, brandGoals] = await Promise.all([
@@ -184,12 +195,14 @@ export function MonthlyViewCharts({
       setCreators(filteredCreators);
       const allIds = filteredCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
+      const productNames = selectedProduct === "all" ? undefined : [selectedProduct];
       const [rows, brandGoals] = await Promise.all([
         getMonthlySpendView({
           brandId: selectedBrandId,
           creatorIds: allIds.length > 0 ? allIds : undefined,
           startDate: format(dateRange.from, "yyyy-MM-dd"),
           endDate: format(dateRange.to, "yyyy-MM-dd"),
+          productNames,
         }),
         getGoalsForBrand(
           selectedBrandId,
@@ -202,17 +215,24 @@ export function MonthlyViewCharts({
     });
   }
 
+  function handleProductChange(value: string) {
+    setSelectedProduct(value);
+    if (selectedBrandId) {
+      fetchData(selectedBrandId, selectedCreatorIds, dateRange, value);
+    }
+  }
+
   function handleCreatorChange(ids: number[]) {
     setSelectedCreatorIds(ids);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, ids, dateRange);
+      fetchData(selectedBrandId, ids, dateRange, selectedProduct);
     }
   }
 
   function handleDateChange(range: { from: Date; to: Date }) {
     setDateRange(range);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, range);
+      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProduct);
     }
   }
 
@@ -264,6 +284,22 @@ export function MonthlyViewCharts({
           onSelectionChange={handleCreatorChange}
           disabled={isPending}
         />
+
+        {products.length > 0 && (
+          <Select value={selectedProduct} onValueChange={handleProductChange}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Todos os produtos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os produtos</SelectItem>
+              {products.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
       <DatePeriodSelector

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -195,7 +195,7 @@ export function PautasTable({
     });
   }, [metrics, sortKey, sortDir, selectedGuidelines]);
 
-  const columns: { key: SortKey; label: string; align?: string }[] = [
+  const columns: { key: SortKey; label: string; align?: string; sortable?: boolean }[] = [
     { key: "guideline_number", label: "Pauta" },
     { key: "spend", label: "Gasto", align: "text-right" },
     { key: "revenue", label: "Revenue", align: "text-right" },
@@ -203,6 +203,7 @@ export function PautasTable({
     { key: "ctr", label: "CTR", align: "text-right" },
     { key: "ad_count", label: "Anúncios", align: "text-center" },
     { key: "creator_count", label: "Creators", align: "text-center" },
+    { key: "product_names", label: "Produto", sortable: false },
     { key: "trend", label: "Tendência", align: "text-right" },
   ];
 
@@ -222,6 +223,8 @@ export function PautasTable({
         return String(row.ad_count);
       case "creator_count":
         return String(row.creator_count);
+      case "product_names":
+        return row.product_names ?? "Não informado";
       case "trend":
         return null;
       default:
@@ -340,11 +343,11 @@ export function PautasTable({
                 {columns.map((col) => (
                   <TableHead
                     key={col.key}
-                    className={`cursor-pointer select-none whitespace-nowrap ${col.align ?? ""}`}
-                    onClick={() => handleSort(col.key)}
+                    className={`${col.sortable === false ? "" : "cursor-pointer"} select-none whitespace-nowrap ${col.align ?? ""}`}
+                    onClick={() => { if (col.sortable !== false) handleSort(col.key); }}
                   >
                     {col.label}
-                    <SortIcon column={col.key} />
+                    {col.sortable !== false && <SortIcon column={col.key} />}
                   </TableHead>
                 ))}
               </TableRow>

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useTransition, useMemo } from "react";
+import { useEffect, useRef, useState, useTransition, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import {
   Table,
   TableBody,
@@ -25,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import {
   getGuidelineMetrics,
   getAvailableMonths,
+  getDistinctProducts,
   type GuidelineMetric,
 } from "@/app/dashboard/pautas/actions";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
@@ -91,17 +93,21 @@ export function PautasTable({
   initialBrandId,
   initialData,
   initialMonths,
+  initialProducts,
 }: {
   brands: Brand[];
   initialBrandId: number | null;
   initialData: GuidelineMetric[];
   initialMonths: string[];
+  initialProducts: string[];
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [metrics, setMetrics] = useState(initialData);
   const [availableMonths, setAvailableMonths] = useState(initialMonths);
+  const [availableProducts, setAvailableProducts] = useState(initialProducts);
   const [selectedMonth, setSelectedMonth] = useState<string>("all");
+  const [selectedProduct, setSelectedProduct] = useState<string>("all");
   const [isPending, startTransition] = useTransition();
   const [sortKey, setSortKey] = useState<SortKey>("roas");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -110,6 +116,34 @@ export function PautasTable({
   const selectedBrandId = searchParams.get("brand")
     ? Number(searchParams.get("brand"))
     : initialBrandId;
+
+  const lastFetchedBrandRef = useRef(initialBrandId);
+
+  useEffect(() => {
+    if (selectedBrandId === lastFetchedBrandRef.current) return;
+    lastFetchedBrandRef.current = selectedBrandId;
+    if (!selectedBrandId) return;
+    setSelectedMonth("all");
+    setSelectedProduct("all");
+    setSelectedGuidelines(new Set());
+    startTransition(async () => {
+      try {
+        const [data, months, products] = await Promise.all([
+          getGuidelineMetrics(selectedBrandId),
+          getAvailableMonths(selectedBrandId),
+          getDistinctProducts(selectedBrandId),
+        ]);
+        setMetrics(data);
+        setAvailableMonths(months);
+        setAvailableProducts(products);
+      } catch {
+        toast.error("Erro ao carregar dados das Pautas");
+        setMetrics([]);
+        setAvailableMonths([]);
+        setAvailableProducts([]);
+      }
+    });
+  }, [selectedBrandId]);
 
   const availableGuidelines = useMemo(
     () => metrics.map((m) => m.guideline_number).sort((a, b) => a - b),
@@ -125,39 +159,34 @@ export function PautasTable({
     });
   }
 
-  function handleBrandChange(value: string) {
-    router.push(`/dashboard/pautas?brand=${value}`);
-    setSelectedMonth("all");
-    setSelectedGuidelines(new Set());
+  function refetch(brandId: number, month: string, product: string) {
+    const monthArg = month === "all" ? undefined : month;
+    const productArg = product === "all" ? undefined : [product];
     startTransition(async () => {
       try {
-        const brandId = Number(value);
-        const [data, months] = await Promise.all([
-          getGuidelineMetrics(brandId),
-          getAvailableMonths(brandId),
-        ]);
+        const data = await getGuidelineMetrics(brandId, monthArg, productArg);
         setMetrics(data);
-        setAvailableMonths(months);
       } catch {
+        toast.error("Erro ao carregar dados das Pautas");
         setMetrics([]);
-        setAvailableMonths([]);
       }
     });
+  }
+
+  function handleBrandChange(value: string) {
+    router.push(`/dashboard/pautas?brand=${value}`);
   }
 
   function handleMonthChange(value: string) {
     setSelectedMonth(value);
     setSelectedGuidelines(new Set());
-    if (!selectedBrandId) return;
-    startTransition(async () => {
-      try {
-        const month = value === "all" ? undefined : value;
-        const data = await getGuidelineMetrics(selectedBrandId, month);
-        setMetrics(data);
-      } catch {
-        setMetrics([]);
-      }
-    });
+    if (selectedBrandId) refetch(selectedBrandId, value, selectedProduct);
+  }
+
+  function handleProductChange(value: string) {
+    setSelectedProduct(value);
+    setSelectedGuidelines(new Set());
+    if (selectedBrandId) refetch(selectedBrandId, selectedMonth, value);
   }
 
   function handleSort(key: SortKey) {
@@ -197,13 +226,13 @@ export function PautasTable({
 
   const columns: { key: SortKey; label: string; align?: string; sortable?: boolean }[] = [
     { key: "guideline_number", label: "Pauta" },
+    { key: "product_names", label: "Produto", sortable: false },
     { key: "spend", label: "Gasto", align: "text-right" },
     { key: "revenue", label: "Revenue", align: "text-right" },
     { key: "roas", label: "ROAS", align: "text-right" },
     { key: "ctr", label: "CTR", align: "text-right" },
     { key: "ad_count", label: "Anúncios", align: "text-center" },
     { key: "creator_count", label: "Creators", align: "text-center" },
-    { key: "product_names", label: "Produto", sortable: false },
     { key: "trend", label: "Tendência", align: "text-right" },
   ];
 
@@ -211,6 +240,8 @@ export function PautasTable({
     switch (key) {
       case "guideline_number":
         return `#${row.guideline_number}`;
+      case "product_names":
+        return row.product_names ?? "Não informado";
       case "spend":
         return formatCurrency(row.spend);
       case "revenue":
@@ -223,8 +254,6 @@ export function PautasTable({
         return String(row.ad_count);
       case "creator_count":
         return String(row.creator_count);
-      case "product_names":
-        return row.product_names ?? "Não informado";
       case "trend":
         return null;
       default:
@@ -280,6 +309,27 @@ export function PautasTable({
             ))}
           </SelectContent>
         </Select>
+
+        {availableProducts.length > 0 && (
+          <>
+            <label className="text-sm font-medium text-muted-foreground">
+              Produto:
+            </label>
+            <Select value={selectedProduct} onValueChange={handleProductChange}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Todos os produtos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos os produtos</SelectItem>
+                {availableProducts.map((p) => (
+                  <SelectItem key={p} value={p}>
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
+        )}
 
         <label className="text-sm font-medium text-muted-foreground">
           Pautas:

--- a/lib/queries/products.ts
+++ b/lib/queries/products.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@/lib/supabase/server";
+
+export async function getDistinctProducts(brandId: number): Promise<string[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("get_distinct_products", {
+    p_brand_id: brandId,
+  });
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row: { product_name: string }) => row.product_name);
+}

--- a/lib/schemas/spend-view.ts
+++ b/lib/schemas/spend-view.ts
@@ -5,6 +5,7 @@ export const spendViewFiltersSchema = z.object({
   creatorIds: z.array(z.number()).optional(),
   startDate: z.string().date("Data inicial inválida"),
   endDate: z.string().date("Data final inválida"),
+  productNames: z.array(z.string()).optional(),
 });
 
 export type SpendViewFilters = z.infer<typeof spendViewFiltersSchema>;

--- a/supabase/functions/sync-ad-metrics/handle-matcher.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher.ts
@@ -21,6 +21,6 @@ export function extractGuidelineNumber(adName: string): number | null {
 }
 
 export function extractProductName(adName: string): string | null {
-  const match = adName.match(/produto\s+([^-]+?)\s*(?:-|$)/i);
+  const match = adName.match(/\bproduto\s+([^-]+?)\s*(?:-|$)/i);
   return match ? match[1].trim() : null;
 }

--- a/supabase/functions/sync-ad-metrics/handle-matcher.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher.ts
@@ -19,3 +19,8 @@ export function extractGuidelineNumber(adName: string): number | null {
   const match = adName.match(/\bpauta\s+(\d+)/i);
   return match ? parseInt(match[1], 10) : null;
 }
+
+export function extractProductName(adName: string): string | null {
+  const match = adName.match(/produto\s+([^-]+?)\s*(?:-|$)/i);
+  return match ? match[1].trim() : null;
+}

--- a/supabase/functions/sync-ad-metrics/handle-matcher_test.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { extractProductName, extractGuidelineNumber } from "./handle-matcher.ts";
+
+Deno.test("extractProductName: extrai nome do produto do ad_name completo", () => {
+  const adName =
+    "@keycemachado - semana 3 - mes 04 - ano 2026 - com headline overlay - pauta 1245 - produto Linha PH - creator";
+  assertEquals(extractProductName(adName), "Linha PH");
+});
+
+Deno.test("extractProductName: lida com variações de espaçamento antes do hífen", () => {
+  assertEquals(extractProductName("produto Linha Detox - creator"), "Linha Detox");
+});
+
+Deno.test("extractProductName: captura produto ao final da string sem hífen", () => {
+  assertEquals(extractProductName("- produto Linha PH"), "Linha PH");
+});
+
+Deno.test("extractProductName: retorna null quando 'produto' não está presente", () => {
+  assertEquals(extractProductName("@creator - pauta 100 - sem info"), null);
+});
+
+Deno.test("extractProductName: case insensitive", () => {
+  assertEquals(extractProductName("PRODUTO Linha PH - creator"), "Linha PH");
+});
+
+Deno.test("extractGuidelineNumber: ainda funciona corretamente após a mudança", () => {
+  assertEquals(
+    extractGuidelineNumber("pauta 1245 - produto Linha PH"),
+    1245,
+  );
+});

--- a/supabase/functions/sync-ad-metrics/handle-matcher_test.ts
+++ b/supabase/functions/sync-ad-metrics/handle-matcher_test.ts
@@ -23,6 +23,10 @@ Deno.test("extractProductName: case insensitive", () => {
   assertEquals(extractProductName("PRODUTO Linha PH - creator"), "Linha PH");
 });
 
+Deno.test("extractProductName: word boundary impede match em 'subproduto'", () => {
+  assertEquals(extractProductName("@creator - subproduto X - foo"), null);
+});
+
 Deno.test("extractGuidelineNumber: ainda funciona corretamente após a mudança", () => {
   assertEquals(
     extractGuidelineNumber("pauta 1245 - produto Linha PH"),

--- a/supabase/functions/sync-ad-metrics/index.ts
+++ b/supabase/functions/sync-ad-metrics/index.ts
@@ -1,6 +1,6 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { MetabaseClient } from "./metabase-client.ts";
-import { matchCreatorBrand, extractGuidelineNumber } from "./handle-matcher.ts";
+import { matchCreatorBrand, extractGuidelineNumber, extractProductName } from "./handle-matcher.ts";
 import { buildMetabaseQuery, buildAccountSpendQuery } from "./queries.ts";
 import type { AdAccount, CreatorBrand, MetabaseRow, SyncResult } from "./types.ts";
 
@@ -274,6 +274,7 @@ async function processAdAccount(
       created_time: createdTime,
       ad_name: adName,
       guideline_number: extractGuidelineNumber(adName),
+      product_name: extractProductName(adName),
     }),
   );
 

--- a/supabase/migrations/20260428131730_add_product_name_to_creatives.sql
+++ b/supabase/migrations/20260428131730_add_product_name_to_creatives.sql
@@ -1,0 +1,3 @@
+alter table "public"."creatives" add column "product_name" text;
+
+

--- a/supabase/migrations/20260428132813_update_guideline_metrics_product_names.sql
+++ b/supabase/migrations/20260428132813_update_guideline_metrics_product_names.sql
@@ -1,18 +1,12 @@
-CREATE OR REPLACE FUNCTION get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL)
-RETURNS TABLE (
-  guideline_number integer,
-  spend numeric,
-  revenue numeric,
-  roas numeric,
-  ctr numeric,
-  creator_count bigint,
-  ad_count bigint,
-  prev_roas numeric,
-  prev_month text,
-  product_names text
-)
-LANGUAGE sql STABLE
-AS $$
+drop function if exists "public"."get_guideline_metrics"(p_brand_id bigint, p_month text);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL::text)
+ RETURNS TABLE(guideline_number integer, spend numeric, revenue numeric, roas numeric, ctr numeric, creator_count bigint, ad_count bigint, prev_roas numeric, prev_month text, product_names text)
+ LANGUAGE sql
+ STABLE
+AS $function$
   WITH monthly_roas AS (
     SELECT
       cr.guideline_number,
@@ -61,17 +55,7 @@ AS $$
     AND (p_month IS NULL OR to_char(am.date, 'YYYY-MM') = p_month)
   GROUP BY cr.guideline_number, pd.prev_roas, pd.prev_month
   ORDER BY roas DESC;
-$$;
+$function$
+;
 
-CREATE OR REPLACE FUNCTION get_guideline_available_months(p_brand_id bigint)
-RETURNS TABLE (month text)
-LANGUAGE sql STABLE
-AS $$
-  SELECT DISTINCT to_char(am.date, 'YYYY-MM') AS month
-  FROM ad_metrics am
-  JOIN creatives cr ON cr.id = am.creative_id
-  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
-  WHERE cb.brand_id = p_brand_id
-    AND cr.guideline_number IS NOT NULL
-  ORDER BY month DESC;
-$$;
+

--- a/supabase/migrations/20260428133338_update_creator_metrics_product_names.sql
+++ b/supabase/migrations/20260428133338_update_creator_metrics_product_names.sql
@@ -1,20 +1,12 @@
-CREATE OR REPLACE FUNCTION get_creator_metrics(p_brand_id bigint)
-RETURNS TABLE (
-  creator text,
-  creator_brand_id bigint,
-  month timestamptz,
-  spend_total numeric,
-  roas_total numeric,
-  ctr_total numeric,
-  spend_recentes numeric,
-  roas_recentes numeric,
-  ctr_recentes numeric,
-  cost numeric,
-  yearly_spend numeric,
-  product_names text
-)
-LANGUAGE sql STABLE
-AS $$
+drop function if exists "public"."get_creator_metrics"(p_brand_id bigint);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_creator_metrics(p_brand_id bigint)
+ RETURNS TABLE(creator text, creator_brand_id bigint, month timestamp with time zone, spend_total numeric, roas_total numeric, ctr_total numeric, spend_recentes numeric, roas_recentes numeric, ctr_recentes numeric, cost numeric, yearly_spend numeric, product_names text)
+ LANGUAGE sql
+ STABLE
+AS $function$
   SELECT
     c.full_name AS creator,
     cb.id AS creator_brand_id,
@@ -63,4 +55,7 @@ AS $$
   WHERE cb.brand_id = p_brand_id
   GROUP BY c.full_name, cb.id, date_trunc('month', am.date), cc.cost
   ORDER BY c.full_name, month DESC;
-$$;
+$function$
+;
+
+

--- a/supabase/migrations/20260428134029_add_product_filter_to_spend_views.sql
+++ b/supabase/migrations/20260428134029_add_product_filter_to_spend_views.sql
@@ -1,0 +1,113 @@
+drop function if exists "public"."get_daily_spend_view"(p_brand_id bigint, p_creator_ids bigint[], p_start_date date, p_end_date date);
+
+drop function if exists "public"."get_monthly_spend_view"(p_brand_id bigint, p_creator_ids bigint[], p_start_date date, p_end_date date);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_daily_spend_view(p_brand_id bigint, p_creator_ids bigint[] DEFAULT NULL::bigint[], p_start_date date DEFAULT NULL::date, p_end_date date DEFAULT NULL::date, p_product_names text[] DEFAULT NULL::text[])
+ RETURNS TABLE(day date, spend_total numeric, spend_recentes numeric, brand_total_spend numeric)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH creator_spend AS (
+    SELECT
+      am.date AS day,
+      COALESCE(SUM(am.spend), 0) AS spend_total,
+      COALESCE(SUM(am.spend) FILTER (
+        WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'
+      ), 0) AS spend_recentes
+    FROM ad_metrics am
+    JOIN creatives cr ON cr.id = am.creative_id
+    JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+    JOIN creators c ON c.id = cb.creator_id
+    WHERE cb.brand_id = p_brand_id
+      AND (p_creator_ids IS NULL OR c.id = ANY(p_creator_ids))
+      AND (p_start_date IS NULL OR am.date >= p_start_date)
+      AND (p_end_date IS NULL OR am.date <= p_end_date)
+      AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
+    GROUP BY am.date
+  ),
+  brand_spend AS (
+    SELECT
+      ds.date AS day,
+      COALESCE(SUM(ds.spend), 0) AS brand_total_spend
+    FROM ad_account_daily_spend ds
+    JOIN ad_accounts aa ON aa.id = ds.ad_account_id
+    WHERE aa.brand_id = p_brand_id
+      AND (p_start_date IS NULL OR ds.date >= p_start_date)
+      AND (p_end_date IS NULL OR ds.date <= p_end_date)
+    GROUP BY ds.date
+  )
+  SELECT
+    COALESCE(cs.day, bs.day) AS day,
+    COALESCE(cs.spend_total, 0) AS spend_total,
+    COALESCE(cs.spend_recentes, 0) AS spend_recentes,
+    COALESCE(bs.brand_total_spend, 0) AS brand_total_spend
+  FROM creator_spend cs
+  FULL OUTER JOIN brand_spend bs ON cs.day = bs.day
+  ORDER BY day;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_distinct_products(p_brand_id bigint)
+ RETURNS TABLE(product_name text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT DISTINCT cr.product_name
+  FROM creatives cr
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.product_name IS NOT NULL
+  ORDER BY cr.product_name;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_monthly_spend_view(p_brand_id bigint, p_creator_ids bigint[] DEFAULT NULL::bigint[], p_start_date date DEFAULT NULL::date, p_end_date date DEFAULT NULL::date, p_product_names text[] DEFAULT NULL::text[])
+ RETURNS TABLE(month date, spend_total numeric, spend_recentes numeric, brand_total_spend numeric)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH creator_spend AS (
+    SELECT
+      date_trunc('month', am.date)::date AS month,
+      COALESCE(SUM(am.spend), 0) AS spend_total,
+      COALESCE(SUM(am.spend) FILTER (
+        WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'
+      ), 0) AS spend_recentes
+    FROM ad_metrics am
+    JOIN creatives cr ON cr.id = am.creative_id
+    JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+    JOIN creators c ON c.id = cb.creator_id
+    WHERE cb.brand_id = p_brand_id
+      AND (p_creator_ids IS NULL OR c.id = ANY(p_creator_ids))
+      AND (p_start_date IS NULL OR am.date >= p_start_date)
+      AND (p_end_date IS NULL OR am.date <= p_end_date)
+      AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
+    GROUP BY date_trunc('month', am.date)::date
+  ),
+  brand_spend AS (
+    SELECT
+      date_trunc('month', ds.date)::date AS month,
+      COALESCE(SUM(ds.spend), 0) AS brand_total_spend
+    FROM ad_account_daily_spend ds
+    JOIN ad_accounts aa ON aa.id = ds.ad_account_id
+    WHERE aa.brand_id = p_brand_id
+      AND (p_start_date IS NULL OR ds.date >= p_start_date)
+      AND (p_end_date IS NULL OR ds.date <= p_end_date)
+    GROUP BY date_trunc('month', ds.date)::date
+  )
+  SELECT
+    COALESCE(cs.month, bs.month) AS month,
+    COALESCE(cs.spend_total, 0) AS spend_total,
+    COALESCE(cs.spend_recentes, 0) AS spend_recentes,
+    COALESCE(bs.brand_total_spend, 0) AS brand_total_spend
+  FROM creator_spend cs
+  FULL OUTER JOIN brand_spend bs ON cs.month = bs.month
+  ORDER BY month;
+$function$
+;
+
+

--- a/supabase/migrations/20260428141806_viz_modes_and_pautas_filter.sql
+++ b/supabase/migrations/20260428141806_viz_modes_and_pautas_filter.sql
@@ -1,31 +1,20 @@
-CREATE OR REPLACE FUNCTION get_creator_metrics(
-  p_brand_id bigint,
-  p_view_mode text DEFAULT 'creator'
-)
-RETURNS TABLE (
-  creator text,
-  creator_brand_id bigint,
-  group_id bigint,
-  product_name text,
-  month timestamptz,
-  spend_total numeric,
-  roas_total numeric,
-  ctr_total numeric,
-  spend_recentes numeric,
-  roas_recentes numeric,
-  ctr_recentes numeric,
-  cost numeric,
-  yearly_spend numeric
-)
-LANGUAGE plpgsql STABLE
-AS $$
+drop function if exists "public"."get_creator_metrics"(p_brand_id bigint);
+
+drop function if exists "public"."get_guideline_metrics"(p_brand_id bigint, p_month text);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_creator_metrics(p_brand_id bigint, p_view_mode text DEFAULT 'creator'::text)
+ RETURNS TABLE(creator text, creator_brand_id bigint, product_name text, month timestamp with time zone, spend_total numeric, roas_total numeric, ctr_total numeric, spend_recentes numeric, roas_recentes numeric, ctr_recentes numeric, cost numeric, yearly_spend numeric)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
 BEGIN
   IF p_view_mode = 'product' THEN
     RETURN QUERY
       SELECT
         NULL::text AS creator,
         NULL::bigint AS creator_brand_id,
-        NULL::bigint AS group_id,
         cr.product_name AS product_name,
         date_trunc('month', am.date) AS month,
         SUM(am.spend) AS spend_total,
@@ -70,7 +59,6 @@ BEGIN
       SELECT
         c.full_name AS creator,
         cb.id AS creator_brand_id,
-        cb.group_id AS group_id,
         cr.product_name AS product_name,
         date_trunc('month', am.date) AS month,
         SUM(am.spend) AS spend_total,
@@ -115,7 +103,6 @@ BEGIN
       SELECT
         c.full_name AS creator,
         cb.id AS creator_brand_id,
-        cb.group_id AS group_id,
         NULL::text AS product_name,
         date_trunc('month', am.date) AS month,
         SUM(am.spend) AS spend_total,
@@ -163,4 +150,79 @@ BEGIN
       ORDER BY c.full_name, month DESC;
   END IF;
 END;
-$$;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL::text, p_product_names text[] DEFAULT NULL::text[])
+ RETURNS TABLE(guideline_number integer, spend numeric, revenue numeric, roas numeric, ctr numeric, creator_count bigint, ad_count bigint, prev_roas numeric, prev_month text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH monthly_roas AS (
+    SELECT
+      cr.guideline_number,
+      to_char(am.date, 'YYYY-MM') AS month,
+      CASE WHEN SUM(am.spend) > 0
+        THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+      END AS roas
+    FROM ad_metrics am
+    JOIN creatives cr ON cr.id = am.creative_id
+    JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+    WHERE cb.brand_id = p_brand_id
+      AND cr.guideline_number IS NOT NULL
+      AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
+    GROUP BY cr.guideline_number, to_char(am.date, 'YYYY-MM')
+  ),
+  prev_data AS (
+    SELECT DISTINCT ON (mr.guideline_number)
+      mr.guideline_number,
+      mr.roas AS prev_roas,
+      mr.month AS prev_month
+    FROM monthly_roas mr
+    WHERE p_month IS NOT NULL
+      AND mr.month < p_month
+    ORDER BY mr.guideline_number, mr.month DESC
+  )
+  SELECT
+    cr.guideline_number,
+    SUM(am.spend) AS spend,
+    SUM(am.revenue) AS revenue,
+    CASE WHEN SUM(am.spend) > 0
+      THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+    END AS roas,
+    CASE WHEN SUM(am.impressions) > 0
+      THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+    END AS ctr,
+    COUNT(DISTINCT cb.creator_id) AS creator_count,
+    COUNT(DISTINCT cr.meta_ad_id) AS ad_count,
+    pd.prev_roas,
+    pd.prev_month
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  LEFT JOIN prev_data pd ON pd.guideline_number = cr.guideline_number
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+    AND (p_month IS NULL OR to_char(am.date, 'YYYY-MM') = p_month)
+    AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
+  GROUP BY cr.guideline_number, pd.prev_roas, pd.prev_month
+  ORDER BY roas DESC;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_available_months(p_brand_id bigint)
+ RETURNS TABLE(month text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT DISTINCT to_char(am.date, 'YYYY-MM') AS month
+  FROM ad_metrics am
+  JOIN creatives cr ON cr.id = am.creative_id
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.guideline_number IS NOT NULL
+  ORDER BY month DESC;
+$function$
+;
+
+

--- a/supabase/migrations/20260428155728_add_product_names_to_guideline_metrics.sql
+++ b/supabase/migrations/20260428155728_add_product_names_to_guideline_metrics.sql
@@ -1,22 +1,12 @@
-CREATE OR REPLACE FUNCTION get_guideline_metrics(
-  p_brand_id bigint,
-  p_month text DEFAULT NULL,
-  p_product_names text[] DEFAULT NULL
-)
-RETURNS TABLE (
-  guideline_number integer,
-  spend numeric,
-  revenue numeric,
-  roas numeric,
-  ctr numeric,
-  creator_count bigint,
-  ad_count bigint,
-  prev_roas numeric,
-  prev_month text,
-  product_names text
-)
-LANGUAGE sql STABLE
-AS $$
+drop function if exists "public"."get_guideline_metrics"(p_brand_id bigint, p_month text, p_product_names text[]);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_guideline_metrics(p_brand_id bigint, p_month text DEFAULT NULL::text, p_product_names text[] DEFAULT NULL::text[])
+ RETURNS TABLE(guideline_number integer, spend numeric, revenue numeric, roas numeric, ctr numeric, creator_count bigint, ad_count bigint, prev_roas numeric, prev_month text, product_names text)
+ LANGUAGE sql
+ STABLE
+AS $function$
   WITH monthly_roas AS (
     SELECT
       cr.guideline_number,
@@ -67,17 +57,7 @@ AS $$
     AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
   GROUP BY cr.guideline_number, pd.prev_roas, pd.prev_month
   ORDER BY roas DESC;
-$$;
+$function$
+;
 
-CREATE OR REPLACE FUNCTION get_guideline_available_months(p_brand_id bigint)
-RETURNS TABLE (month text)
-LANGUAGE sql STABLE
-AS $$
-  SELECT DISTINCT to_char(am.date, 'YYYY-MM') AS month
-  FROM ad_metrics am
-  JOIN creatives cr ON cr.id = am.creative_id
-  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
-  WHERE cb.brand_id = p_brand_id
-    AND cr.guideline_number IS NOT NULL
-  ORDER BY month DESC;
-$$;
+

--- a/supabase/migrations/20260428170339_restore_group_id_and_word_boundary.sql
+++ b/supabase/migrations/20260428170339_restore_group_id_and_word_boundary.sql
@@ -1,0 +1,157 @@
+drop function if exists "public"."get_creator_metrics"(p_brand_id bigint, p_view_mode text);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_creator_metrics(p_brand_id bigint, p_view_mode text DEFAULT 'creator'::text)
+ RETURNS TABLE(creator text, creator_brand_id bigint, group_id bigint, product_name text, month timestamp with time zone, spend_total numeric, roas_total numeric, ctr_total numeric, spend_recentes numeric, roas_recentes numeric, ctr_recentes numeric, cost numeric, yearly_spend numeric)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+  IF p_view_mode = 'product' THEN
+    RETURN QUERY
+      SELECT
+        NULL::text AS creator,
+        NULL::bigint AS creator_brand_id,
+        NULL::bigint AS group_id,
+        cr.product_name AS product_name,
+        date_trunc('month', am.date) AS month,
+        SUM(am.spend) AS spend_total,
+        CASE WHEN SUM(am.spend) > 0
+          THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+        END AS roas_total,
+        CASE WHEN SUM(am.impressions) > 0
+          THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+        END AS ctr_total,
+        SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') AS spend_recentes,
+        CASE WHEN SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            SUM(am.revenue) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month')
+            / SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'), 2)
+          ELSE 0
+        END AS roas_recentes,
+        CASE WHEN SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            (SUM(am.link_clicks) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'))::numeric
+            / SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') * 100, 2)
+          ELSE 0
+        END AS ctr_recentes,
+        NULL::numeric AS cost,
+        NULL::numeric AS yearly_spend
+      FROM ad_metrics am
+      JOIN creatives cr ON cr.id = am.creative_id
+      JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+      WHERE cb.brand_id = p_brand_id
+        AND cr.product_name IS NOT NULL
+      GROUP BY cr.product_name, date_trunc('month', am.date)
+      ORDER BY cr.product_name, month DESC;
+
+  ELSIF p_view_mode = 'granular' THEN
+    RETURN QUERY
+      SELECT
+        c.full_name AS creator,
+        cb.id AS creator_brand_id,
+        cb.group_id AS group_id,
+        cr.product_name AS product_name,
+        date_trunc('month', am.date) AS month,
+        SUM(am.spend) AS spend_total,
+        CASE WHEN SUM(am.spend) > 0
+          THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+        END AS roas_total,
+        CASE WHEN SUM(am.impressions) > 0
+          THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+        END AS ctr_total,
+        SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') AS spend_recentes,
+        CASE WHEN SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            SUM(am.revenue) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month')
+            / SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'), 2)
+          ELSE 0
+        END AS roas_recentes,
+        CASE WHEN SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            (SUM(am.link_clicks) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'))::numeric
+            / SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') * 100, 2)
+          ELSE 0
+        END AS ctr_recentes,
+        NULL::numeric AS cost,
+        NULL::numeric AS yearly_spend
+      FROM ad_metrics am
+      JOIN creatives cr ON cr.id = am.creative_id
+      JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+      JOIN creators c ON c.id = cb.creator_id
+      WHERE cb.brand_id = p_brand_id
+      GROUP BY c.full_name, cb.id, cr.product_name, date_trunc('month', am.date)
+      ORDER BY c.full_name, cr.product_name NULLS LAST, month DESC;
+
+  ELSE
+    RETURN QUERY
+      SELECT
+        c.full_name AS creator,
+        cb.id AS creator_brand_id,
+        cb.group_id AS group_id,
+        NULL::text AS product_name,
+        date_trunc('month', am.date) AS month,
+        SUM(am.spend) AS spend_total,
+        CASE WHEN SUM(am.spend) > 0
+          THEN ROUND(SUM(am.revenue) / SUM(am.spend), 2) ELSE 0
+        END AS roas_total,
+        CASE WHEN SUM(am.impressions) > 0
+          THEN ROUND(SUM(am.link_clicks)::numeric / SUM(am.impressions) * 100, 2) ELSE 0
+        END AS ctr_total,
+        SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') AS spend_recentes,
+        CASE WHEN SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            SUM(am.revenue) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month')
+            / SUM(am.spend) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'), 2)
+          ELSE 0
+        END AS roas_recentes,
+        CASE WHEN SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+          AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') > 0
+          THEN ROUND(
+            (SUM(am.link_clicks) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month'))::numeric
+            / SUM(am.impressions) FILTER (WHERE cr.created_time >= date_trunc('month', am.date) - INTERVAL '1 month'
+              AND cr.created_time < date_trunc('month', am.date) + INTERVAL '1 month') * 100, 2)
+          ELSE 0
+        END AS ctr_recentes,
+        cc.cost AS cost,
+        SUM(SUM(am.spend)) OVER (
+          PARTITION BY cb.id, EXTRACT(YEAR FROM date_trunc('month', am.date))
+          ORDER BY date_trunc('month', am.date)
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS yearly_spend
+      FROM ad_metrics am
+      JOIN creatives cr ON cr.id = am.creative_id
+      JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+      JOIN creators c ON c.id = cb.creator_id
+      LEFT JOIN creator_costs cc
+        ON cc.creator_brand_id = cb.id
+        AND cc.month = date_trunc('month', am.date)::date
+      WHERE cb.brand_id = p_brand_id
+      GROUP BY c.full_name, cb.id, date_trunc('month', am.date), cc.cost
+      ORDER BY c.full_name, month DESC;
+  END IF;
+END;
+$function$
+;
+
+

--- a/supabase/schemas/06_creatives.sql
+++ b/supabase/schemas/06_creatives.sql
@@ -7,6 +7,7 @@ create table if not exists "public"."creatives" (
   "ad_name" text,
   "guideline_number" integer,
   "created_at" timestamptz not null default now(),
+  "product_name" text,
 
   constraint "creatives_pkey" primary key ("id"),
   constraint "creatives_meta_ad_id_key" unique ("meta_ad_id"),

--- a/supabase/schemas/11_get_monthly_spend_view.sql
+++ b/supabase/schemas/11_get_monthly_spend_view.sql
@@ -2,7 +2,8 @@ CREATE OR REPLACE FUNCTION get_monthly_spend_view(
   p_brand_id bigint,
   p_creator_ids bigint[] DEFAULT NULL,
   p_start_date date DEFAULT NULL,
-  p_end_date date DEFAULT NULL
+  p_end_date date DEFAULT NULL,
+  p_product_names text[] DEFAULT NULL
 )
 RETURNS TABLE (
   month date,
@@ -28,6 +29,7 @@ AS $$
       AND (p_creator_ids IS NULL OR c.id = ANY(p_creator_ids))
       AND (p_start_date IS NULL OR am.date >= p_start_date)
       AND (p_end_date IS NULL OR am.date <= p_end_date)
+      AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
     GROUP BY date_trunc('month', am.date)::date
   ),
   brand_spend AS (

--- a/supabase/schemas/12_get_daily_spend_view.sql
+++ b/supabase/schemas/12_get_daily_spend_view.sql
@@ -2,7 +2,8 @@ CREATE OR REPLACE FUNCTION get_daily_spend_view(
   p_brand_id bigint,
   p_creator_ids bigint[] DEFAULT NULL,
   p_start_date date DEFAULT NULL,
-  p_end_date date DEFAULT NULL
+  p_end_date date DEFAULT NULL,
+  p_product_names text[] DEFAULT NULL
 )
 RETURNS TABLE (
   day date,
@@ -28,6 +29,7 @@ AS $$
       AND (p_creator_ids IS NULL OR c.id = ANY(p_creator_ids))
       AND (p_start_date IS NULL OR am.date >= p_start_date)
       AND (p_end_date IS NULL OR am.date <= p_end_date)
+      AND (p_product_names IS NULL OR cr.product_name = ANY(p_product_names))
     GROUP BY am.date
   ),
   brand_spend AS (

--- a/supabase/schemas/19_get_distinct_products.sql
+++ b/supabase/schemas/19_get_distinct_products.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION get_distinct_products(p_brand_id bigint)
+RETURNS TABLE (product_name text)
+LANGUAGE sql STABLE
+AS $$
+  SELECT DISTINCT cr.product_name
+  FROM creatives cr
+  JOIN creator_brands cb ON cb.id = cr.creator_brand_id
+  WHERE cb.brand_id = p_brand_id
+    AND cr.product_name IS NOT NULL
+  ORDER BY cr.product_name;
+$$;


### PR DESCRIPTION
## Sumário

Adiciona a dimensão **produto** ao dashboard, extraindo `product_name` do `ad_name` via regex no ETL e expondo em quatro telas:

- **Pautas** (`/dashboard/pautas`): coluna **Produto** ao lado da Pauta + filtro Produto.
- **Tabela Mensal** (`/dashboard/creators`): ToggleGroup de visão — `Por Creator` (default) / `Por Produto` / `Granular`. Cada modo reorganiza linhas e colunas.
- **Visão Mensal** (`/dashboard/monthly-view`) e **Visão Diária** (`/dashboard/daily-view`): novo Select de produto na barra de filtros dos charts.

## Mudanças por camada

### ETL
- `extractProductName()` em `handle-matcher.ts` — regex `/\bproduto\s+([^-]+?)\s*(?:-|$)/i`, case-insensitive, com word boundary (não casa `subproduto`).
- Persiste `product_name` (nullable) na tabela `creatives` em todo upsert.
- Cobertura de testes (Deno) incluindo edge case de `subproduto`.

### Banco — 7 migrations encadeadas
1. `20260428131730_add_product_name_to_creatives` — adiciona coluna nullable
2. `20260428132813_update_guideline_metrics_product_names` — STRING_AGG no retorno
3. `20260428133338_update_creator_metrics_product_names` — idem na RPC de creators
4. `20260428134029_add_product_filter_to_spend_views` — `p_product_names` em monthly/daily spend views + cria `get_distinct_products`
5. `20260428141806_viz_modes_and_pautas_filter` — RPC creators ganha `p_view_mode` (creator/product/granular); RPC pautas ganha `p_product_names`
6. `20260428155728_add_product_names_to_guideline_metrics` — restaura STRING_AGG após o overhaul
7. `20260428170339_restore_group_id_and_word_boundary` — restaura `group_id` no retorno de get_creator_metrics (consertando filtro de Grupo que estava broken pré-PR)

> Todas idempotentes (DROP+CREATE em sequência). Testadas localmente.

### UI/UX
- **Tabela Mensal**: ToggleGroup com 3 modos. Trocar visão reseta filtros de Mês/Grupo. Filtro de Grupo aparece só em `Por Creator`. InlineEditCost só ativo onde `creator_brand_id != null`.
- **Pautas**: `useEffect` em `selectedBrandId` faz back/forward navigation funcionar (recarrega meses + produtos + métricas).
- **Charts**: produto como filtro Single-select. `brand_total_spend` (denominador do share%) **não** é filtrado por produto — propositalmente, para o share% representar a fatia do produto no total da marca.
- Toasts de erro nos catches que antes eram silenciosos.
- Validação Zod do array `productNames` em `spend-view.ts`.

## ⚠️ Passos OBRIGATÓRIOS pós-merge

A app **não funcionará corretamente** até esses passos serem executados na ordem.

### 1. Aplicar migrations em produção
\`\`\`bash
supabase db push
\`\`\`
Confirma a aplicação das 7 migrations listadas acima. Sem isso, a app em prod vai falhar nas chamadas de RPC (assinaturas mudaram).

### 2. Deploy da Edge Function ETL
\`\`\`bash
supabase functions deploy sync-ad-metrics
\`\`\`
A função foi modificada para extrair e gravar \`product_name\`. Sem o deploy, novos sincs continuam gravando \`NULL\`.

### 3. Backfill dos criativos existentes
Criativos cadastrados antes do deploy ainda terão \`product_name = NULL\`. Para popular retroativamente, dispare um backfill que reprocessa o histórico:
\`\`\`bash
supabase functions invoke sync-ad-metrics --body '{\"trigger\":\"backfill\"}'
\`\`\`
Ou via UI em \`/dashboard/sync\` (se exposto). O ETL é idempotente — re-execuções não duplicam dados.

### 4. (Opcional, recomendado) Verificar grupos
Esta PR consertou o retorno de \`group_id\` em \`get_creator_metrics\`, que estava quebrado desde a migration \`20260408021545\`. O filtro de Grupo na Tabela Mensal voltará a funcionar — vale validar que os grupos cadastrados aparecem corretamente no dropdown.

## Decisões de produto registradas

- **Coluna Produto removida do modo \"Por Creator\"** — o usuário acessa via toggle. Mantém a tabela default enxuta.
- **Filtro single-select** nos charts e em Pautas (não multi-select) — UX mais simples; pode evoluir para multi se demandado.
- **Share% mantém denominador total da marca** mesmo com filtro de produto ativo — assim a métrica representa a fatia do produto no orçamento total.

## Test plan

### Local (já validado)
- [x] Type-check passa (`npx tsc --noEmit`)
- [x] Build passa (`npm run build`)
- [x] Migrations aplicam em sequência sem erro
- [x] Smoke test das RPCs no Postgres local
- [x] Testes Deno do ETL escritos (não executados — Deno não instalado no ambiente local; rodar com \`deno test supabase/functions/sync-ad-metrics/handle-matcher_test.ts\` antes do deploy)

### Produção (após merge)
- [ ] Migrations aplicadas via \`supabase db push\`
- [ ] Edge Function deployed
- [ ] Backfill executado em ao menos uma marca
- [ ] \`/dashboard/pautas\`: coluna Produto preenchida; filtro Produto retorna pautas só daquele produto
- [ ] \`/dashboard/creators\`: toggle alterna entre os 3 modos sem erros; colunas mudam corretamente
- [ ] \`/dashboard/monthly-view\` e \`/dashboard/daily-view\`: filtro de produto re-renderiza charts com dados consistentes
- [ ] Filtro de Grupo na Tabela Mensal funciona (regression check)
- [ ] Browser back/forward em Pautas mantém estado coerente

## Arquivos com maior risco
- \`supabase/schemas/15_get_creator_metrics.sql\` — PL/pgSQL com 3 ramos (creator/product/granular). Testar todos os modos com dados reais.
- \`supabase/functions/sync-ad-metrics/handle-matcher.ts\` — regex em produção. Acompanhar logs do primeiro backfill para verificar taxa de extração.

🤖 Generated with [Claude Code](https://claude.com/claude-code)