### PR TITLE
fix(dashboard): truncate long product names so all columns stay visible

### DIFF
--- a/components/creators-table.tsx
+++ b/components/creators-table.tsx
@@ -361,7 +361,10 @@ export function CreatorsTable({
                 sorted.map((row, i) => (
                   <TableRow key={rowKey(row, i)}>
                     {columns.map((col) => (
-                      <TableCell key={col.key} className="whitespace-nowrap">
+                      <TableCell
+                        key={col.key}
+                        className={`whitespace-nowrap ${col.key === "product_name" ? "max-w-[260px]" : ""}`}
+                      >
                         {col.key === "cost" && viewMode === "creator" && row.creator_brand_id != null ? (
                           <InlineEditCost
                             value={row.cost}
@@ -376,6 +379,13 @@ export function CreatorsTable({
                               if (originalIndex !== -1) handleCostSaved(originalIndex, newCost);
                             }}
                           />
+                        ) : col.key === "product_name" ? (
+                          <span
+                            className="block truncate"
+                            title={row.product_name ?? "Não informado"}
+                          >
+                            {row.product_name ?? "Não informado"}
+                          </span>
                         ) : (
                           formatCell(row, col.key)
                         )}

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -428,11 +428,18 @@ export function PautasTable({
                     {columns.map((col) => (
                       <TableCell
                         key={col.key}
-                        className={`whitespace-nowrap ${col.align ?? ""} ${col.key === "roas" ? roasColor(row.roas) : ""}`}
+                        className={`whitespace-nowrap ${col.align ?? ""} ${col.key === "roas" ? roasColor(row.roas) : ""} ${col.key === "product_names" ? "max-w-[280px]" : ""}`}
                       >
                         {col.key === "trend" ? (
                           <span className={formatTrend(row).color}>
                             {formatTrend(row).text}
+                          </span>
+                        ) : col.key === "product_names" ? (
+                          <span
+                            className="block truncate"
+                            title={row.product_names ?? "Não informado"}
+                          >
+                            {row.product_names ?? "Não informado"}
                           </span>
                         ) : (
                           formatCell(row, col.key)


### PR DESCRIPTION
## Sumário

Em produção, pautas com `STRING_AGG` de vários produtos (ex: \"Body Splash My Sweet Delight..., Body Splash Sienna Glow..., Body Splash Very Sexy...\") estavam empurrando o resto das colunas (Gasto/Revenue/ROAS/CTR/Anúncios/Creators/Tendência) pra fora da viewport.

## Mudança

- `components/pautas-table.tsx` — célula \"Produto\" ganha `max-w-[280px]` + `truncate`. Texto completo aparece em tooltip nativo (atributo \`title\`) ao passar o mouse.
- `components/creators-table.tsx` — mesma técnica para \"Produto\" nos modos `Por Produto` e `Granular` da Tabela Mensal (`max-w-[260px]`).

## Fora de escopo

Considerei mostrar só o primeiro produto + badge \"+N\" mas deixei pra próxima iteração — truncar+tooltip é mais simples e resolve o problema imediato.

## Test plan

- [x] Type-check passa
- [ ] Pautas: marca com produtos longos exibe todas as colunas sem scroll horizontal forçado
- [ ] Hover na célula Produto mostra texto completo
- [ ] Tabela Mensal modo \"Por Produto\" e \"Granular\": mesmo comportamento
- [ ] Sem regressão em modo \"Por Creator\" (não tem coluna Produto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)