### PR TITLE
feat(filters): multi-select de produtos em Pautas, Visão Mensal e Visão Diária

### DIFF
--- a/components/daily-view-charts.tsx
+++ b/components/daily-view-charts.tsx
@@ -17,6 +17,7 @@ import {
   CreatorMultiSelect,
   type CreatorOption,
 } from "@/components/creator-multi-select";
+import { ProductMultiSelect } from "@/components/product-multi-select";
 import {
   DatePeriodSelector,
   type DatePreset,
@@ -126,7 +127,7 @@ export function DailyViewCharts({
   const [groups, setGroups] = useState<GroupOption[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("all");
   const [products, setProducts] = useState<string[]>([]);
-  const [selectedProduct, setSelectedProduct] = useState<string>("all");
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
 
   useEffect(() => {
     if (selectedBrandId) {
@@ -146,17 +147,16 @@ export function DailyViewCharts({
   }, [selectedBrandId]);
 
   const fetchData = useCallback(
-    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, product: string) => {
+    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, productNames: string[]) => {
       startTransition(async () => {
         const allSelected = creatorIds.length === 0;
-        const productNames = product === "all" ? undefined : [product];
         const [rows, brandGoals] = await Promise.all([
           getDailySpendView({
             brandId,
             creatorIds: allSelected ? undefined : creatorIds,
             startDate: format(range.from, "yyyy-MM-dd"),
             endDate: format(range.to, "yyyy-MM-dd"),
-            productNames,
+            productNames: productNames.length === 0 ? undefined : productNames,
           }),
           getGoalsForBrand(
             brandId,
@@ -175,7 +175,7 @@ export function DailyViewCharts({
     const brandId = Number(value);
     setSelectedBrandId(brandId);
     setSelectedGroupId("all");
-    setSelectedProduct("all");
+    setSelectedProducts([]);
     router.push(`/dashboard/daily-view?brand=${brandId}`);
     startTransition(async () => {
       const newCreators = await getCreatorsByBrand(brandId);
@@ -210,7 +210,7 @@ export function DailyViewCharts({
       setCreators(filteredCreators);
       const allIds = filteredCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
-      const productNames = selectedProduct === "all" ? undefined : [selectedProduct];
+      const productNames = selectedProducts.length === 0 ? undefined : selectedProducts;
       const [rows, brandGoals] = await Promise.all([
         getDailySpendView({
           brandId: selectedBrandId,
@@ -230,24 +230,24 @@ export function DailyViewCharts({
     });
   }
 
-  function handleProductChange(value: string) {
-    setSelectedProduct(value);
+  function handleProductsChange(values: string[]) {
+    setSelectedProducts(values);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, dateRange, value);
+      fetchData(selectedBrandId, selectedCreatorIds, dateRange, values);
     }
   }
 
   function handleCreatorChange(ids: number[]) {
     setSelectedCreatorIds(ids);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, ids, dateRange, selectedProduct);
+      fetchData(selectedBrandId, ids, dateRange, selectedProducts);
     }
   }
 
   function handleDateChange(range: { from: Date; to: Date }) {
     setDateRange(range);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProduct);
+      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProducts);
     }
   }
 
@@ -301,19 +301,12 @@ export function DailyViewCharts({
         />
 
         {products.length > 0 && (
-          <Select value={selectedProduct} onValueChange={handleProductChange}>
-            <SelectTrigger className="w-[200px]">
-              <SelectValue placeholder="Todos os produtos" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos os produtos</SelectItem>
-              {products.map((p) => (
-                <SelectItem key={p} value={p}>
-                  {p}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <ProductMultiSelect
+            products={products}
+            selected={selectedProducts}
+            onSelectionChange={handleProductsChange}
+            disabled={isPending}
+          />
         )}
       </div>
 

--- a/components/monthly-view-charts.tsx
+++ b/components/monthly-view-charts.tsx
@@ -17,6 +17,7 @@ import {
   CreatorMultiSelect,
   type CreatorOption,
 } from "@/components/creator-multi-select";
+import { ProductMultiSelect } from "@/components/product-multi-select";
 import {
   DatePeriodSelector,
   type DatePreset,
@@ -115,7 +116,7 @@ export function MonthlyViewCharts({
   const [groups, setGroups] = useState<GroupOption[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("all");
   const [products, setProducts] = useState<string[]>([]);
-  const [selectedProduct, setSelectedProduct] = useState<string>("all");
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
 
   useEffect(() => {
     if (selectedBrandId) {
@@ -135,17 +136,16 @@ export function MonthlyViewCharts({
   }, [selectedBrandId]);
 
   const fetchData = useCallback(
-    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, product: string) => {
+    (brandId: number, creatorIds: number[], range: { from: Date; to: Date }, productNames: string[]) => {
       startTransition(async () => {
         const allSelected = creatorIds.length === 0;
-        const productNames = product === "all" ? undefined : [product];
         const [rows, brandGoals] = await Promise.all([
           getMonthlySpendView({
             brandId,
             creatorIds: allSelected ? undefined : creatorIds,
             startDate: format(range.from, "yyyy-MM-dd"),
             endDate: format(range.to, "yyyy-MM-dd"),
-            productNames,
+            productNames: productNames.length === 0 ? undefined : productNames,
           }),
           getGoalsForBrand(
             brandId,
@@ -164,7 +164,7 @@ export function MonthlyViewCharts({
     const brandId = Number(value);
     setSelectedBrandId(brandId);
     setSelectedGroupId("all");
-    setSelectedProduct("all");
+    setSelectedProducts([]);
     router.push(`/dashboard/monthly-view?brand=${brandId}`);
     startTransition(async () => {
       const newCreators = await getCreatorsByBrand(brandId);
@@ -199,7 +199,7 @@ export function MonthlyViewCharts({
       setCreators(filteredCreators);
       const allIds = filteredCreators.map((c) => c.id);
       setSelectedCreatorIds(allIds);
-      const productNames = selectedProduct === "all" ? undefined : [selectedProduct];
+      const productNames = selectedProducts.length === 0 ? undefined : selectedProducts;
       const [rows, brandGoals] = await Promise.all([
         getMonthlySpendView({
           brandId: selectedBrandId,
@@ -219,24 +219,24 @@ export function MonthlyViewCharts({
     });
   }
 
-  function handleProductChange(value: string) {
-    setSelectedProduct(value);
+  function handleProductsChange(values: string[]) {
+    setSelectedProducts(values);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, dateRange, value);
+      fetchData(selectedBrandId, selectedCreatorIds, dateRange, values);
     }
   }
 
   function handleCreatorChange(ids: number[]) {
     setSelectedCreatorIds(ids);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, ids, dateRange, selectedProduct);
+      fetchData(selectedBrandId, ids, dateRange, selectedProducts);
     }
   }
 
   function handleDateChange(range: { from: Date; to: Date }) {
     setDateRange(range);
     if (selectedBrandId) {
-      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProduct);
+      fetchData(selectedBrandId, selectedCreatorIds, range, selectedProducts);
     }
   }
 
@@ -290,19 +290,12 @@ export function MonthlyViewCharts({
         />
 
         {products.length > 0 && (
-          <Select value={selectedProduct} onValueChange={handleProductChange}>
-            <SelectTrigger className="w-[200px]">
-              <SelectValue placeholder="Todos os produtos" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos os produtos</SelectItem>
-              {products.map((p) => (
-                <SelectItem key={p} value={p}>
-                  {p}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <ProductMultiSelect
+            products={products}
+            selected={selectedProducts}
+            onSelectionChange={handleProductsChange}
+            disabled={isPending}
+          />
         )}
       </div>
 

--- a/components/pautas-table.tsx
+++ b/components/pautas-table.tsx
@@ -23,6 +23,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { ProductMultiSelect } from "@/components/product-multi-select";
 import {
   getGuidelineMetrics,
   getAvailableMonths,
@@ -107,7 +108,7 @@ export function PautasTable({
   const [availableMonths, setAvailableMonths] = useState(initialMonths);
   const [availableProducts, setAvailableProducts] = useState(initialProducts);
   const [selectedMonth, setSelectedMonth] = useState<string>("all");
-  const [selectedProduct, setSelectedProduct] = useState<string>("all");
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
   const [sortKey, setSortKey] = useState<SortKey>("roas");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -124,7 +125,7 @@ export function PautasTable({
     lastFetchedBrandRef.current = selectedBrandId;
     if (!selectedBrandId) return;
     setSelectedMonth("all");
-    setSelectedProduct("all");
+    setSelectedProducts([]);
     setSelectedGuidelines(new Set());
     startTransition(async () => {
       try {
@@ -159,9 +160,9 @@ export function PautasTable({
     });
   }
 
-  function refetch(brandId: number, month: string, product: string) {
+  function refetch(brandId: number, month: string, products: string[]) {
     const monthArg = month === "all" ? undefined : month;
-    const productArg = product === "all" ? undefined : [product];
+    const productArg = products.length === 0 ? undefined : products;
     startTransition(async () => {
       try {
         const data = await getGuidelineMetrics(brandId, monthArg, productArg);
@@ -180,13 +181,13 @@ export function PautasTable({
   function handleMonthChange(value: string) {
     setSelectedMonth(value);
     setSelectedGuidelines(new Set());
-    if (selectedBrandId) refetch(selectedBrandId, value, selectedProduct);
+    if (selectedBrandId) refetch(selectedBrandId, value, selectedProducts);
   }
 
-  function handleProductChange(value: string) {
-    setSelectedProduct(value);
+  function handleProductsChange(values: string[]) {
+    setSelectedProducts(values);
     setSelectedGuidelines(new Set());
-    if (selectedBrandId) refetch(selectedBrandId, selectedMonth, value);
+    if (selectedBrandId) refetch(selectedBrandId, selectedMonth, values);
   }
 
   function handleSort(key: SortKey) {
@@ -315,19 +316,11 @@ export function PautasTable({
             <label className="text-sm font-medium text-muted-foreground">
               Produto:
             </label>
-            <Select value={selectedProduct} onValueChange={handleProductChange}>
-              <SelectTrigger className="w-[200px]">
-                <SelectValue placeholder="Todos os produtos" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos os produtos</SelectItem>
-                {availableProducts.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <ProductMultiSelect
+              products={availableProducts}
+              selected={selectedProducts}
+              onSelectionChange={handleProductsChange}
+            />
           </>
         )}
 

--- a/components/product-multi-select.tsx
+++ b/components/product-multi-select.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronsUpDown, Package } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface ProductMultiSelectProps {
+  products: string[];
+  selected: string[];
+  onSelectionChange: (names: string[]) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ProductMultiSelect({
+  products,
+  selected,
+  onSelectionChange,
+  disabled,
+  className,
+}: ProductMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const allSelected = selected.length === products.length && products.length > 0;
+
+  function toggleProduct(name: string) {
+    if (selected.includes(name)) {
+      onSelectionChange(selected.filter((s) => s !== name));
+    } else {
+      onSelectionChange([...selected, name]);
+    }
+  }
+
+  function toggleAll() {
+    if (allSelected || selected.length === 0) {
+      onSelectionChange(allSelected ? [] : products);
+    } else {
+      onSelectionChange(products);
+    }
+  }
+
+  const label =
+    selected.length === 0 || allSelected
+      ? "Todos os produtos"
+      : selected.length === 1
+        ? selected[0]
+        : `${selected.length} produtos`;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn("w-[240px] justify-between", className)}
+          disabled={disabled}
+        >
+          <Package className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <span className="truncate">{label}</span>
+          <ChevronsUpDown className="ml-auto h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[280px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Buscar produto..." />
+          <CommandList>
+            <CommandEmpty>Nenhum produto encontrado.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem onSelect={toggleAll}>
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    allSelected ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                Selecionar todos
+              </CommandItem>
+              {products.map((name) => (
+                <CommandItem
+                  key={name}
+                  value={name}
+                  onSelect={() => toggleProduct(name)}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selected.includes(name) ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="truncate">{name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Sumário

Substitui o filtro de Produto (Select single-select) por um multi-select com Popover + Command + Checkbox. Permite filtrar por vários produtos simultaneamente em três telas:

- /dashboard/pautas
- /dashboard/monthly-view
- /dashboard/daily-view

## Mudanças

- **Novo**: \`components/product-multi-select.tsx\` — componente reutilizável seguindo o mesmo padrão do \`CreatorMultiSelect\` existente. Tem busca, \"Selecionar todos\" e label dinâmico (\"Todos os produtos\" / \"Bolsa Joy\" / \"3 produtos\").
- \`components/pautas-table.tsx\` — substitui Select; estado vira \`selectedProducts: string[]\`.
- \`components/monthly-view-charts.tsx\` e \`components/daily-view-charts.tsx\` — idem.

## Sem mudanças no banco

As RPCs \`get_guideline_metrics\`, \`get_monthly_spend_view\` e \`get_daily_spend_view\` já aceitam \`p_product_names text[]\` desde a feature inicial. Esta PR só passa um array de >1 elemento quando o usuário seleciona múltiplos.

## Test plan

- [x] Type-check passa
- [ ] Pautas: selecionar 2-3 produtos retorna pautas que tenham QUALQUER um dos selecionados
- [ ] Visão Mensal: filtro com múltiplos produtos atualiza os charts agregando o gasto deles
- [ ] Visão Diária: idem
- [ ] \"Selecionar todos\" e clear funcionam
- [ ] Sem regressão: trocar marca reseta o filtro pra \"Todos\"

## Notas pra deploy
Sem migrations. Só Vercel auto-deploy do front. Não conflita com PR #42 (truncate) — toca lugares diferentes do mesmo arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)